### PR TITLE
Add self-play RL training pipeline, agent adapters, and Elo league

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ while not done:
     done = terminated or truncated
 ```
 
+### Self-Play Training (MaskablePPO)
+Run an overnight training job with periodic Elo evaluation:
+```bash
+python -m rl.train --config configs/overnight.yaml
+```
+
+Run a quick smoke test (~1 minute) that trains briefly and updates Elo across 10 matches:
+```bash
+python -m rl.smoke_test
+```
+
 ### Running Agent Arena
 
 Run round-robin tournaments between agents:
@@ -559,4 +570,3 @@ This project is part of a reinforcement learning research environment.
 
 Old Mockups 
 <img width="2816" height="1536" alt="BlokusRL" src="https://github.com/user-attachments/assets/93e85cd8-c5fe-4785-ae13-810327a1aa07" />
-

--- a/agents/registry.py
+++ b/agents/registry.py
@@ -1,0 +1,130 @@
+"""
+Agent registry and unified act() protocol for Blokus.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+import numpy as np
+
+from agents.heuristic_agent import HeuristicAgent
+from agents.random_agent import RandomAgent
+from agents.fast_mcts_agent import FastMCTSAgent
+from mcts.mcts_agent import MCTSAgent
+
+
+class AgentProtocol(Protocol):
+    """Unified interface: act(observation, legal_mask) -> action index."""
+
+    def act(self, observation: np.ndarray, legal_mask: np.ndarray, env=None) -> Optional[int]:
+        ...
+
+
+@dataclass
+class AgentSpec:
+    name: str
+    agent_type: str
+    version: Optional[str] = None
+    checkpoint_path: Optional[str] = None
+
+
+class RandomAgentAdapter:
+    def __init__(self, seed: Optional[int] = None):
+        self.agent = RandomAgent(seed=seed)
+
+    def act(self, observation: np.ndarray, legal_mask: np.ndarray, env=None) -> Optional[int]:
+        if legal_mask is None or not legal_mask.any():
+            return None
+        action_ids = np.flatnonzero(legal_mask)
+        if action_ids.size == 0:
+            return None
+        return int(np.random.choice(action_ids))
+
+
+class HeuristicAgentAdapter:
+    def __init__(self, seed: Optional[int] = None):
+        self.agent = HeuristicAgent(seed=seed)
+
+    def act(self, observation: np.ndarray, legal_mask: np.ndarray, env=None) -> Optional[int]:
+        if env is None:
+            return None
+        base_env = env.env if hasattr(env, "env") else env
+        player_name = base_env.agent_selection
+        legal_moves = env.get_legal_moves(player_name) if hasattr(env, "get_legal_moves") else base_env.move_generator.get_legal_moves(
+            base_env.game.board, base_env._agent_to_player(player_name)
+        )
+        if not legal_moves:
+            return None
+        player = base_env._agent_to_player(player_name)
+        move = self.agent.select_action(base_env.game.board, player, legal_moves)
+        if move is None:
+            return None
+        return base_env.move_to_action.get((move.piece_id, move.orientation, move.anchor_row, move.anchor_col))
+
+
+class MCTSAgentAdapter:
+    def __init__(self, seed: Optional[int] = None, iterations: int = 200, time_limit: Optional[float] = None):
+        self.agent = MCTSAgent(iterations=iterations, time_limit=time_limit, seed=seed)
+
+    def act(self, observation: np.ndarray, legal_mask: np.ndarray, env=None) -> Optional[int]:
+        if env is None:
+            return None
+        base_env = env.env if hasattr(env, "env") else env
+        player_name = base_env.agent_selection
+        legal_moves = env.get_legal_moves(player_name) if hasattr(env, "get_legal_moves") else base_env.move_generator.get_legal_moves(
+            base_env.game.board, base_env._agent_to_player(player_name)
+        )
+        if not legal_moves:
+            return None
+        player = base_env._agent_to_player(player_name)
+        move = self.agent.select_action(base_env.game.board, player, legal_moves)
+        if move is None:
+            return None
+        return base_env.move_to_action.get((move.piece_id, move.orientation, move.anchor_row, move.anchor_col))
+
+
+class FastMCTSAgentAdapter:
+    def __init__(self, seed: Optional[int] = None, time_limit: float = 0.05):
+        self.agent = FastMCTSAgent(time_limit=time_limit, seed=seed)
+
+    def act(self, observation: np.ndarray, legal_mask: np.ndarray, env=None) -> Optional[int]:
+        if env is None:
+            return None
+        base_env = env.env if hasattr(env, "env") else env
+        player_name = base_env.agent_selection
+        legal_moves = env.get_legal_moves(player_name) if hasattr(env, "get_legal_moves") else base_env.move_generator.get_legal_moves(
+            base_env.game.board, base_env._agent_to_player(player_name)
+        )
+        if not legal_moves:
+            return None
+        player = base_env._agent_to_player(player_name)
+        move = self.agent.select_action(base_env.game.board, player, legal_moves)
+        if move is None:
+            return None
+        return base_env.move_to_action.get((move.piece_id, move.orientation, move.anchor_row, move.anchor_col))
+
+
+class RLPolicyAgent:
+    def __init__(self, model):
+        self.model = model
+
+    def act(self, observation: np.ndarray, legal_mask: np.ndarray, env=None) -> Optional[int]:
+        if legal_mask is None or not legal_mask.any():
+            return None
+        action, _ = self.model.predict(observation, action_masks=legal_mask, deterministic=True)
+        return int(action)
+
+
+def build_baseline_agent(agent_type: str, seed: Optional[int] = None) -> AgentProtocol:
+    agent_type = agent_type.lower()
+    if agent_type == "random":
+        return RandomAgentAdapter(seed=seed)
+    if agent_type == "heuristic":
+        return HeuristicAgentAdapter(seed=seed)
+    if agent_type == "mcts":
+        return MCTSAgentAdapter(seed=seed)
+    if agent_type == "fast_mcts":
+        return FastMCTSAgentAdapter(seed=seed)
+    raise ValueError(f"Unknown agent type: {agent_type}")

--- a/configs/overnight.yaml
+++ b/configs/overnight.yaml
@@ -1,0 +1,20 @@
+seed: 42
+total_timesteps: 300000
+learning_rate: 0.0003
+n_steps: 2048
+batch_size: 256
+gamma: 0.99
+num_envs: 2
+vec_env_type: dummy
+max_episode_steps: 1000
+opponents:
+  - heuristic
+  - random
+  - random
+eval_interval_steps: 20000
+eval_matches: 10
+checkpoint_interval_steps: 50000
+checkpoint_dir: checkpoints/rl
+log_dir: logs/rl
+league_db: league.db
+tensorboard: false

--- a/league/__init__.py
+++ b/league/__init__.py
@@ -1,0 +1,1 @@
+"""League and Elo utilities."""

--- a/league/db.py
+++ b/league/db.py
@@ -1,0 +1,138 @@
+"""
+SQLite persistence for Elo league data.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+
+
+class LeagueDB:
+    def __init__(self, path: str = "league.db"):
+        self.path = path
+        self._conn = sqlite3.connect(self.path)
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS agents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                type TEXT NOT NULL,
+                version TEXT,
+                checkpoint_path TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS ratings (
+                agent_id INTEGER PRIMARY KEY,
+                elo REAL NOT NULL,
+                FOREIGN KEY(agent_id) REFERENCES agents(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS matches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent1_id INTEGER NOT NULL,
+                agent2_id INTEGER NOT NULL,
+                result REAL NOT NULL,
+                seed INTEGER,
+                timestamp TEXT NOT NULL,
+                FOREIGN KEY(agent1_id) REFERENCES agents(id) ON DELETE CASCADE,
+                FOREIGN KEY(agent2_id) REFERENCES agents(id) ON DELETE CASCADE
+            );
+            """
+        )
+        self._conn.commit()
+
+    def add_agent(
+        self,
+        name: str,
+        agent_type: str,
+        version: Optional[str] = None,
+        checkpoint_path: Optional[str] = None,
+        initial_elo: float = 1200.0,
+    ) -> int:
+        now = datetime.utcnow().isoformat()
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO agents (name, type, version, checkpoint_path, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (name, agent_type, version, checkpoint_path, now),
+        )
+        self._conn.commit()
+        agent_id = self.get_agent_id(name)
+        if agent_id is not None:
+            cursor.execute(
+                "INSERT OR IGNORE INTO ratings (agent_id, elo) VALUES (?, ?)",
+                (agent_id, initial_elo),
+            )
+            self._conn.commit()
+        return agent_id
+
+    def get_agent_id(self, name: str) -> Optional[int]:
+        cursor = self._conn.execute("SELECT id FROM agents WHERE name = ?", (name,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    def get_agent(self, name: str) -> Optional[Dict[str, Any]]:
+        cursor = self._conn.execute(
+            "SELECT id, name, type, version, checkpoint_path FROM agents WHERE name = ?",
+            (name,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "name": row[1],
+            "type": row[2],
+            "version": row[3],
+            "checkpoint_path": row[4],
+        }
+
+    def record_match(self, agent1_id: int, agent2_id: int, result: float, seed: Optional[int]) -> None:
+        now = datetime.utcnow().isoformat()
+        self._conn.execute(
+            """
+            INSERT INTO matches (agent1_id, agent2_id, result, seed, timestamp)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (agent1_id, agent2_id, result, seed, now),
+        )
+        self._conn.commit()
+
+    def update_rating(self, agent_id: int, new_elo: float) -> None:
+        self._conn.execute(
+            "UPDATE ratings SET elo = ? WHERE agent_id = ?",
+            (new_elo, agent_id),
+        )
+        self._conn.commit()
+
+    def get_rating(self, agent_id: int) -> float:
+        cursor = self._conn.execute("SELECT elo FROM ratings WHERE agent_id = ?", (agent_id,))
+        row = cursor.fetchone()
+        return float(row[0]) if row else 1200.0
+
+    def leaderboard(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        query = """
+            SELECT agents.name, agents.type, agents.version, ratings.elo
+            FROM ratings
+            JOIN agents ON agents.id = ratings.agent_id
+            ORDER BY ratings.elo DESC
+        """
+        if limit:
+            query += " LIMIT ?"
+            rows = self._conn.execute(query, (limit,)).fetchall()
+        else:
+            rows = self._conn.execute(query).fetchall()
+        return [
+            {"name": row[0], "type": row[1], "version": row[2], "elo": row[3]}
+            for row in rows
+        ]
+
+    def close(self) -> None:
+        self._conn.close()

--- a/league/elo.py
+++ b/league/elo.py
@@ -1,0 +1,25 @@
+"""
+Elo rating helpers for Blokus agent league.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EloConfig:
+    k_factor: float = 32.0
+    draw_score: float = 0.5
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    return 1.0 / (1.0 + 10 ** ((rating_b - rating_a) / 400.0))
+
+
+def update_ratings(rating_a: float, rating_b: float, result_a: float, config: EloConfig) -> tuple[float, float]:
+    expected_a = expected_score(rating_a, rating_b)
+    expected_b = expected_score(rating_b, rating_a)
+    new_a = rating_a + config.k_factor * (result_a - expected_a)
+    new_b = rating_b + config.k_factor * ((1.0 - result_a) - expected_b)
+    return new_a, new_b

--- a/league/league.py
+++ b/league/league.py
@@ -1,0 +1,151 @@
+"""
+League orchestration: scheduling, matches, and Elo updates.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Dict, Optional, List, Tuple
+
+import numpy as np
+
+from envs.blokus_v0 import BlokusEnv
+from agents.registry import AgentProtocol, AgentSpec, build_baseline_agent, RLPolicyAgent
+from league.db import LeagueDB
+from league.elo import EloConfig, update_ratings
+
+
+@dataclass
+class MatchResult:
+    winner: Optional[str]
+    scores: Dict[str, int]
+    moves_made: int
+
+
+class League:
+    def __init__(self, db_path: str = "league.db", elo_config: Optional[EloConfig] = None):
+        self.db = LeagueDB(db_path)
+        self.elo_config = elo_config or EloConfig()
+
+    def register_agent(self, spec: AgentSpec, initial_elo: float = 1200.0) -> int:
+        return self.db.add_agent(
+            name=spec.name,
+            agent_type=spec.agent_type,
+            version=spec.version,
+            checkpoint_path=spec.checkpoint_path,
+            initial_elo=initial_elo,
+        )
+
+    def play_match(
+        self,
+        agent1_name: str,
+        agent2_name: str,
+        agent1: AgentProtocol,
+        agent2: AgentProtocol,
+        seed: Optional[int] = None,
+        max_moves: int = 1000,
+    ) -> MatchResult:
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+        env = BlokusEnv(max_episode_steps=max_moves)
+        env.reset(seed=seed)
+
+        proxy = MatchEnvProxy(env)
+        agent_map = {
+            "player_0": agent1,
+            "player_1": agent2,
+            "player_2": agent2,
+            "player_3": agent1,
+        }
+        moves_made = 0
+        winner = None
+
+        while env.agents and moves_made < max_moves:
+            agent_name = env.agent_selection
+            if env.terminations.get(agent_name, False) or env.truncations.get(agent_name, False):
+                env.step(None)
+                moves_made += 1
+                continue
+            obs = env.observe(agent_name)
+            info = env.infos[agent_name]
+            legal_mask = info["legal_action_mask"]
+            action = agent_map[agent_name].act(obs, legal_mask, env=proxy)
+            env.step(action)
+            moves_made += 1
+            if all(env.terminations.get(agent, False) or env.truncations.get(agent, False) for agent in env.agents):
+                break
+
+        scores = {
+            agent1_name: env.game.get_score(env._agent_to_player("player_0")),
+            agent2_name: env.game.get_score(env._agent_to_player("player_1")),
+        }
+        if scores[agent1_name] > scores[agent2_name]:
+            winner = agent1_name
+        elif scores[agent2_name] > scores[agent1_name]:
+            winner = agent2_name
+        else:
+            winner = None
+
+        return MatchResult(winner=winner, scores=scores, moves_made=moves_made)
+
+    def update_elo(self, agent1_name: str, agent2_name: str, result: float, seed: Optional[int]) -> None:
+        agent1_id = self.db.get_agent_id(agent1_name)
+        agent2_id = self.db.get_agent_id(agent2_name)
+        if agent1_id is None or agent2_id is None:
+            raise ValueError("Both agents must be registered before updating Elo.")
+
+        rating1 = self.db.get_rating(agent1_id)
+        rating2 = self.db.get_rating(agent2_id)
+        new_r1, new_r2 = update_ratings(rating1, rating2, result, self.elo_config)
+        self.db.update_rating(agent1_id, new_r1)
+        self.db.update_rating(agent2_id, new_r2)
+        self.db.record_match(agent1_id, agent2_id, result, seed)
+
+    def leaderboard(self, limit: Optional[int] = None):
+        return self.db.leaderboard(limit=limit)
+
+    def close(self):
+        self.db.close()
+
+
+class MatchEnvProxy:
+    """
+    Provides a minimal wrapper for AgentProtocol adapters during league matches.
+    """
+
+    def __init__(self, env: BlokusEnv):
+        self.env = env
+        self.move_generator = env.move_generator
+        self._cache = {}
+
+    def get_legal_moves(self, player_name: str):
+        player = self.env._agent_to_player(player_name)
+        key = (self.env.step_count, player.value)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        moves = self.move_generator.get_legal_moves(self.env.game.board, player)
+        self._cache[key] = moves
+        return moves
+
+def build_league_agents(
+    baseline_types: List[str],
+    seed: Optional[int],
+    model=None,
+    model_name: Optional[str] = None,
+) -> Tuple[Dict[str, AgentProtocol], List[AgentSpec]]:
+    agents: Dict[str, AgentProtocol] = {}
+    specs: List[AgentSpec] = []
+
+    for agent_type in baseline_types:
+        name = f"{agent_type}_baseline"
+        agents[name] = build_baseline_agent(agent_type, seed=seed)
+        specs.append(AgentSpec(name=name, agent_type=agent_type))
+
+    if model is not None and model_name is not None:
+        agents[model_name] = RLPolicyAgent(model)
+        specs.append(AgentSpec(name=model_name, agent_type="rl", checkpoint_path=model_name))
+
+    return agents, specs

--- a/rl/__init__.py
+++ b/rl/__init__.py
@@ -1,0 +1,1 @@
+"""RL training utilities for Blokus."""

--- a/rl/env_wrapper.py
+++ b/rl/env_wrapper.py
@@ -1,0 +1,138 @@
+"""
+Self-play Gymnasium wrapper for Blokus with configurable opponents.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Dict, Optional, Tuple
+
+import gymnasium as gym
+import numpy as np
+
+from envs.blokus_v0 import BlokusEnv
+from mcts.zobrist import ZobristHash
+from agents.registry import AgentProtocol, build_baseline_agent
+
+logger = logging.getLogger(__name__)
+
+
+class SelfPlayBlokusEnv(gym.Env):
+    """
+    Gymnasium-compatible single-agent wrapper that plays against opponent agents.
+
+    The learning agent always controls player_0. All other players are driven by
+    the provided opponent agents via their AgentProtocol interface.
+    """
+
+    metadata = {"render_modes": [None, "human"]}
+
+    def __init__(
+        self,
+        render_mode: Optional[str] = None,
+        max_episode_steps: int = 1000,
+        opponents: Optional[Dict[str, AgentProtocol]] = None,
+        cache_size: int = 2048,
+        seed: Optional[int] = None,
+    ):
+        self.env = BlokusEnv(render_mode=render_mode, max_episode_steps=max_episode_steps)
+        self.agent_name = "player_0"
+        self.action_space = self.env.action_space
+        self.observation_space = self.env.observation_space
+        self.render_mode = render_mode
+        self._opponents = opponents or self._default_opponents(seed)
+        self._zobrist = ZobristHash(seed=seed)
+        self._move_cache: "OrderedDict[Tuple[int, int], Tuple[list, list]]" = OrderedDict()
+        self._cache_size = cache_size
+
+    def _default_opponents(self, seed: Optional[int]) -> Dict[str, AgentProtocol]:
+        return {
+            "player_1": build_baseline_agent("heuristic", seed=seed),
+            "player_2": build_baseline_agent("random", seed=seed),
+            "player_3": build_baseline_agent("random", seed=seed),
+        }
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        self.env.reset(seed=seed, options=options)
+        self._move_cache.clear()
+        obs = self.env.observe(self.agent_name)
+        info = self.env.infos[self.agent_name]
+        return obs, info
+
+    def step(self, action: int):
+        self.env.step(action)
+        self._advance_opponents()
+
+        obs = self.env.observe(self.agent_name)
+        reward = self.env.rewards[self.agent_name]
+        terminated = self.env.terminations[self.agent_name]
+        truncated = self.env.truncations[self.agent_name]
+        info = self.env.infos[self.agent_name]
+        return obs, reward, terminated, truncated, info
+
+    def _advance_opponents(self) -> None:
+        max_iterations = len(self.env.agents) * 2
+        iterations = 0
+
+        while self.env.agent_selection != self.agent_name and iterations < max_iterations:
+            current_agent = self.env.agent_selection
+            if self.env.terminations.get(current_agent, False) or self.env.truncations.get(current_agent, False):
+                self.env.step(None)
+                iterations += 1
+                continue
+
+            opponent = self._opponents.get(current_agent)
+            if opponent is None:
+                self.env.step(None)
+                iterations += 1
+                continue
+
+            obs = self.env.observe(current_agent)
+            legal_mask = self.env.infos[current_agent]["legal_action_mask"]
+            action = opponent.act(obs, legal_mask, env=self)
+            if action is None:
+                self.env.step(None)
+            else:
+                self.env.step(int(action))
+            iterations += 1
+
+    def get_action_mask(self) -> np.ndarray:
+        return self.env.infos[self.agent_name]["legal_action_mask"]
+
+    def get_legal_moves(self, player_name: str):
+        player = self.env._agent_to_player(player_name)
+        board_hash = self._zobrist.hash_board(self.env.game.board)
+        cache_key = (board_hash, player.value)
+        cached = self._move_cache.get(cache_key)
+        if cached is not None:
+            self._move_cache.move_to_end(cache_key)
+            return cached[0]
+
+        legal_moves = self.env.move_generator.get_legal_moves(self.env.game.board, player)
+        action_ids = [
+            self.env.move_to_action.get((move.piece_id, move.orientation, move.anchor_row, move.anchor_col))
+            for move in legal_moves
+        ]
+        self._move_cache[cache_key] = (legal_moves, action_ids)
+        if len(self._move_cache) > self._cache_size:
+            self._move_cache.popitem(last=False)
+        return legal_moves
+
+    def get_action_ids(self, player_name: str):
+        player = self.env._agent_to_player(player_name)
+        board_hash = self._zobrist.hash_board(self.env.game.board)
+        cache_key = (board_hash, player.value)
+        cached = self._move_cache.get(cache_key)
+        if cached is not None:
+            self._move_cache.move_to_end(cache_key)
+            return cached[1]
+
+        self.get_legal_moves(player_name)
+        return self._move_cache.get(cache_key, ([], []))[1]
+
+    def render(self):
+        return self.env.render()
+
+    def close(self):
+        self.env.close()

--- a/rl/smoke_test.py
+++ b/rl/smoke_test.py
@@ -1,0 +1,31 @@
+"""
+Smoke test: tiny training run and Elo updates.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from rl.train import TrainConfig, train
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        config = TrainConfig(
+            seed=7,
+            total_timesteps=2000,
+            n_steps=256,
+            batch_size=64,
+            num_envs=1,
+            eval_interval_steps=1000,
+            eval_matches=10,
+            checkpoint_interval_steps=2000,
+            checkpoint_dir=f"{tmp_dir}/checkpoints",
+            log_dir=f"{tmp_dir}/logs",
+            league_db=f"{tmp_dir}/league.db",
+        )
+        train(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/train.py
+++ b/rl/train.py
@@ -1,0 +1,261 @@
+"""
+Self-play training pipeline for Blokus using MaskablePPO.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import pickle
+import random
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+import yaml
+from sb3_contrib import MaskablePPO
+from sb3_contrib.common.wrappers import ActionMasker
+from stable_baselines3.common.monitor import Monitor
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+from agents.registry import RLPolicyAgent, build_baseline_agent, AgentSpec
+from league.league import League
+from rl.env_wrapper import SelfPlayBlokusEnv
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrainConfig:
+    seed: int = 0
+    total_timesteps: int = 200_000
+    learning_rate: float = 3e-4
+    n_steps: int = 2048
+    batch_size: int = 256
+    gamma: float = 0.99
+    num_envs: int = 1
+    vec_env_type: str = "dummy"
+    max_episode_steps: int = 1000
+    opponents: List[str] = field(default_factory=lambda: ["heuristic", "random", "random"])
+    eval_interval_steps: int = 20_000
+    eval_matches: int = 10
+    checkpoint_interval_steps: int = 50_000
+    checkpoint_dir: str = "checkpoints/rl"
+    log_dir: str = "logs/rl"
+    league_db: str = "league.db"
+    tensorboard: bool = False
+    resume_path: Optional[str] = None
+
+
+def set_seeds(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def load_config(path: str) -> TrainConfig:
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle) or {}
+    config = TrainConfig()
+    for key, value in raw.items():
+        if hasattr(config, key):
+            setattr(config, key, value)
+    return config
+
+
+def make_env(config: TrainConfig, seed_offset: int = 0):
+    def _init():
+        env = SelfPlayBlokusEnv(
+            max_episode_steps=config.max_episode_steps,
+            opponents=_build_opponents(config, config.seed + seed_offset),
+            seed=config.seed + seed_offset,
+        )
+        env = Monitor(env)
+        env = ActionMasker(env, lambda e: e.get_action_mask())
+        return env
+
+    return _init
+
+
+def _build_opponents(config: TrainConfig, seed: int):
+    opponent_agents = {}
+    player_names = ["player_1", "player_2", "player_3"]
+    for name, agent_type in zip(player_names, config.opponents):
+        opponent_agents[name] = build_baseline_agent(agent_type, seed=seed)
+    return opponent_agents
+
+
+def _make_vec_env(config: TrainConfig):
+    if config.num_envs <= 1:
+        return DummyVecEnv([make_env(config, seed_offset=0)])
+    env_fns = [make_env(config, seed_offset=i) for i in range(config.num_envs)]
+    if config.vec_env_type == "subproc":
+        return SubprocVecEnv(env_fns)
+    return DummyVecEnv(env_fns)
+
+
+def _save_checkpoint(model: MaskablePPO, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    model.save(str(path))
+    rng_state = {
+        "random": random.getstate(),
+        "numpy": np.random.get_state(),
+        "torch": torch.get_rng_state(),
+    }
+    with open(path.with_suffix(".rng.pkl"), "wb") as handle:
+        pickle.dump(rng_state, handle)
+
+
+def _load_checkpoint(model_path: str, env):
+    model = MaskablePPO.load(model_path, env=env)
+    rng_path = Path(model_path).with_suffix(".rng.pkl")
+    if rng_path.exists():
+        with open(rng_path, "rb") as handle:
+            rng_state = pickle.load(handle)
+        random.setstate(rng_state["random"])
+        np.random.set_state(rng_state["numpy"])
+        torch.set_rng_state(rng_state["torch"])
+    return model
+
+
+def _estimate_games_per_sec(env) -> float:
+    episode_lengths = []
+    if hasattr(env, "envs"):
+        for sub_env in env.envs:
+            monitor = sub_env
+            while hasattr(monitor, "env"):
+                if hasattr(monitor, "episode_lengths"):
+                    episode_lengths.extend(monitor.episode_lengths)
+                    break
+                monitor = monitor.env
+    elif hasattr(env, "episode_lengths"):
+        episode_lengths.extend(env.episode_lengths)
+    if not episode_lengths:
+        return 0.0
+    avg_length = float(np.mean(episode_lengths))
+    steps_per_sec = getattr(env, "steps_per_sec", 0.0)
+    return steps_per_sec / max(avg_length, 1.0)
+
+
+def evaluate_and_update_league(
+    model: MaskablePPO,
+    league: League,
+    config: TrainConfig,
+    step: int,
+) -> Dict[str, Any]:
+    baseline_types = list({*config.opponents, "mcts"})
+    agents = {}
+    for agent_type in baseline_types:
+        name = f"{agent_type}_baseline"
+        agents[name] = build_baseline_agent(agent_type, seed=config.seed)
+        league.register_agent(AgentSpec(name=name, agent_type=agent_type))
+    agents["rl_checkpoint"] = RLPolicyAgent(model)
+    league.register_agent(AgentSpec(name="rl_checkpoint", agent_type="rl", version=str(step)))
+
+    results = {"wins": 0, "losses": 0, "draws": 0}
+    for match_id in range(config.eval_matches):
+        opponent_type = random.choice(baseline_types)
+        opponent_name = f"{opponent_type}_baseline"
+        rl_name = "rl_checkpoint"
+        seed = config.seed + step + match_id
+        match = league.play_match(
+            rl_name,
+            opponent_name,
+            agents[rl_name],
+            agents[opponent_name],
+            seed=seed,
+        )
+        if match.winner == rl_name:
+            results["wins"] += 1
+            result = 1.0
+        elif match.winner is None:
+            results["draws"] += 1
+            result = 0.5
+        else:
+            results["losses"] += 1
+            result = 0.0
+        league.update_elo(rl_name, opponent_name, result, seed)
+
+    return results
+
+
+def train(config: TrainConfig) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    set_seeds(config.seed)
+
+    env = _make_vec_env(config)
+    tensorboard_log = config.log_dir if config.tensorboard else None
+
+    if config.resume_path:
+        model = _load_checkpoint(config.resume_path, env)
+    else:
+        model = MaskablePPO(
+            "CnnPolicy",
+            env,
+            learning_rate=config.learning_rate,
+            n_steps=config.n_steps,
+            batch_size=config.batch_size,
+            gamma=config.gamma,
+            verbose=1,
+            tensorboard_log=tensorboard_log,
+        )
+
+    league = League(db_path=config.league_db)
+    log_path = Path(config.log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+    metrics_path = log_path / "train_metrics.jsonl"
+
+    start_time = time.time()
+    steps_done = 0
+    while steps_done < config.total_timesteps:
+        remaining = config.total_timesteps - steps_done
+        chunk = min(config.eval_interval_steps, remaining)
+        chunk_start = time.time()
+        model.learn(total_timesteps=chunk, reset_num_timesteps=False)
+        chunk_time = time.time() - chunk_start
+        steps_done += chunk
+        steps_per_sec = chunk / max(chunk_time, 1e-6)
+        env.steps_per_sec = steps_per_sec
+
+        eval_results = evaluate_and_update_league(model, league, config, steps_done)
+        checkpoint_path = Path(config.checkpoint_dir) / f"checkpoint_{steps_done}.zip"
+        if steps_done % config.checkpoint_interval_steps == 0 or steps_done >= config.total_timesteps:
+            _save_checkpoint(model, checkpoint_path)
+
+        metrics = {
+            "step": steps_done,
+            "elapsed_sec": time.time() - start_time,
+            "steps_per_sec": steps_per_sec,
+            "games_per_sec_est": _estimate_games_per_sec(env),
+            "eval": eval_results,
+        }
+        with open(metrics_path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(metrics) + "\n")
+
+        logger.info(
+            "Step %s | %s steps/s | eval W/L/D: %s/%s/%s",
+            steps_done,
+            f"{steps_per_sec:.1f}",
+            eval_results["wins"],
+            eval_results["losses"],
+            eval_results["draws"],
+        )
+
+    league.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train Blokus self-play agent (MaskablePPO)")
+    parser.add_argument("--config", type=str, default="configs/overnight.yaml")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    config = load_config(args.config)
+    train(config)


### PR DESCRIPTION
### Motivation

- Provide a self-play training workflow for Blokus so an RL policy can be trained against configurable baseline opponents and evaluated periodically. 
- Track and compare agents over time with an Elo-backed league to persist results and rank checkpoints.

### Description

- Added a Gymnasium single-agent self-play wrapper `SelfPlayBlokusEnv` that runs opponent agents automatically, exposes `get_action_mask`, and caches legal moves using `ZobristHash` to speed repeated lookups (`rl/env_wrapper.py`).
- Introduced a unified agent protocol and adapters (`RandomAgentAdapter`, `HeuristicAgentAdapter`, `MCTSAgentAdapter`, `FastMCTSAgentAdapter`, `RLPolicyAgent`) and a `build_baseline_agent` factory to simplify plugging agents into training and league code (`agents/registry.py`).
- Implemented an Elo subsystem with SQLite persistence (`LeagueDB`) and helpers (`EloConfig`, `update_ratings`) plus a `League` orchestrator that runs matches, updates ratings, and provides a `MatchEnvProxy` for adapter compatibility (`league/elo.py`, `league/db.py`, `league/league.py`).
- Added a MaskablePPO-based training script with vectorized env creation, action masking, periodic evaluation against baselines, checkpointing with RNG state save/load, and metrics logging (`rl/train.py`).
- Added a small smoke test to exercise a short training+evaluation loop (`rl/smoke_test.py`), an overnight config (`configs/overnight.yaml`), and README snippets documenting how to run training and the smoke test (`README.md`).

### Testing

- No automated tests were executed as part of this change. 
- A runnable smoke test was added and can be executed with `python -m rl.smoke_test` for a short validation run that trains briefly and performs Elo updates. 
- The new training entrypoint can be started with `python -m rl.train --config configs/overnight.yaml` for full training and evaluation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c33f15b408321abc4fab46ced94b7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a full self-play RL workflow and persistent Elo league for evaluating agents and checkpoints.
> 
> - New `SelfPlayBlokusEnv` wrapper runs opponents automatically, exposes `get_action_mask`, and caches legal moves via `ZobristHash` (`rl/env_wrapper.py`)
> - Unified agent interface (`AgentProtocol`) with adapters (`Random/Heuristic/MCTS/FastMCTS`) and `RLPolicyAgent`; factory `build_baseline_agent` (`agents/registry.py`)
> - Elo subsystem with SQLite storage (`LeagueDB`), rating helpers, and `League` orchestrator + `MatchEnvProxy` to run matches and update ratings (`league/db.py`, `league/elo.py`, `league/league.py`)
> - Training script using `MaskablePPO`, vectorized envs, action masking, periodic evaluation, checkpointing with RNG state, and metrics logging (`rl/train.py`); config file `configs/overnight.yaml`
> - Quick smoke test to validate end-to-end training and Elo updates (`rl/smoke_test.py`)
> - README updated with self-play training and smoke test commands
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2139cd8a65d2a5529c4caaff796282306d64e99d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->