### PR TITLE
# Piece Placement Translation & Dashboard Restructuring

### DIFF
--- a/docs/meta/PR_DESCRIPTION.md
+++ b/docs/meta/PR_DESCRIPTION.md
@@ -1,34 +1,24 @@
-# Dashboard Visual Overhaul and Frontend Metrics Calculation
+# Piece Placement Translation & Dashboard Restructuring
 
 ## Overview
-This PR completely overhauls the game analysis dashboard, providing detailed spatial metrics and predictive visualizations based on the current board state and historical game progression. All advanced metrics are now calculated locally on the frontend, ensuring compatibility with previously exported game history JSON files.
+This PR addresses crucial bugs in how piece orientations were communicated between the frontend and the Pyodide Web Worker, and restructures the Telemetry Dashboard to better accommodate the predictive charts.
 
-## Key Features & Changes
+## Changes Included
 
-### Frontend Metric Calculations (`dashboardMetrics.ts`)
-Calculates heavy spatial data purely on the client side:
-- **True Dead-Zones**: Implements an 8-way (Chebyshev) BFS to detect empty cells fully disconnected by pieces from ever being reached by specific players.
-- **Influence Maps (Voronoi)**: Computes a true multi-source distance map to show territory dominance and highly contested areas.
-- **Win Probability Heuristic**: Real-time evaluation combining board score (pieces placed), spatial influence, and frontier mobility. 
+### 🐛 Bug Fixes: Frontend-Backend Orientation Translation (Web Worker)
+*   **The Issue**: The frontend UI cycled through a fixed 8-state index (0-7) for rotations and flips. However, the Blokus engine dynamically deduplicates shapes to optimize generation. This means symmetrical pieces (like the 1-square or a 2x2 square) expected fewer than 8 orientation indices, immediately leading to out-of-bounds errors or incorrect shape matching when a player rotated a piece.
+*   **The Fix**: Implemented a bidirectional translation layer in `browser_python/worker_bridge.py`. 
+    *   **Inbound**: Translates the frontend's raw 0-7 rotation index to the exact matching `orientation_id` the engine expects based on normalized shape offsets.
+    *   **Outbound**: Translates the backend's unique `orientation_id` back to the frontend's 0-7 index for legal move highlights, heatmap overlays, and game history restoration.
 
-### `AnalysisDashboard.tsx` 3-Column Redesign
-Restructured into a responsive layout with cohesive aesthetic styling:
-*   **Predictive Line Charts**:
-    - Corner Differential (Mobility over time)
-    - Mobility (Frontier Size over time)
-*   **Spatial Analysis**:
-    - Combined side-by-side view for `Frontier` maps and `Endgame Dead-Zones`.
-    - Integrated a unified player-color toggle to dynamically analyze spaces globally for any given player.
-*   **Game State & Player Status**:
-    - Replaced the redundant piece tray view with a compact *Pieces Remaining By Size* table.
-    - Added a *Territory Control* pie chart showing current influence distributions.
-    - Updated the layout and colors to match the neon palette and deep charcoal background used in the primary game grid. 
+### 🎨 Feature: Dashboard Layout Restructuring
+*   **Chart Resizing**: Transformed the `FrontierMap` and `DeadZoneMap` cells in `AnalysisDashboard.tsx` into strict squares to match the actual Blokus board aspect ratio.
+*   **Layout Adjustments**: Modifed the dashboard layout to place the predictive line charts (Frontier Size and Corner Differential) in a wider 6-column container, providing more horizontal space. The spatial grid components were stacked vertically into a 3-column container alongside them.
+*   **Tab Simplification**: Removed the redundant "Events" and "Charts / Dashboard" sub-tabs inside `TelemetryPanel.tsx`. Selecting the main "Dashboard" tab now immediately renders the Analysis Dashboard.
+*   **Strategy Documentation**: Created a detailed `strategy_metrics.md` guide documenting the calculated metrics and outlining potential new MCTS agent "personalities" (e.g., Expansionist, Survivor, Aggressor).
 
-### Game State Persistence & UI Refinements
-- **Save/Load Functionality**: Added "Save Game" functionality to the main `Play.tsx` header (and Game Over screen) that exports `game_history` as a serialized JSON file.
-- **Hydration**: Added a hidden "Load Game from File" input natively into `GameConfigModal.tsx` under custom options and deployment profiles. Uploading a previous JSON file perfectly hydrates the new dashboard data.
-- **Resizable Right Panel**: Implemented a draggable col-resize handle between the main game board and the right dashboard/telemetry drawer for customizable workspace real estate.
-
-## Technical Notes
-- Removed the old `Live Legal Moves` chart to condense real estate in favor of broader strategic insight tools.
-- Ensured all color references use the unified neon theme tokens from `gameConstants.ts`.
+## How to Test
+1.  Start a fresh Local WebWorker game.
+2.  Pick up an asymmetrical piece (like Piece #9 or #10). Rotate (`R`) and Flip (`F`) the piece.
+3.  Attempt to place the piece on valid anchor points. Confirm placement succeeds without the previous Warning #9 or #10 console messages, and that the piece visually matches what you placed.
+4.  Navigate to the `Dashboard` tab next to `Game` and observe the new, streamlined view with square spatial grides and wider predictive charts.

--- a/frontend/src/components/AnalysisDashboard.tsx
+++ b/frontend/src/components/AnalysisDashboard.tsx
@@ -102,7 +102,7 @@ export const AnalysisDashboard: React.FC = () => {
             <div className="flex-1 p-3 grid grid-cols-1 lg:grid-cols-12 gap-3 min-h-0 overflow-y-auto">
 
                 {/* LEFT COLUMN: Predictive Line Charts */}
-                <div className="lg:col-span-3 flex flex-col gap-3 min-h-0">
+                <div className="lg:col-span-6 flex flex-col gap-3 min-h-0">
                     <SectionTitle title="Predictive Line Charts" />
 
                     <div className="flex-1 min-h-[160px] bg-charcoal-800 border border-charcoal-700 rounded-lg p-2 flex flex-col hover:border-gray-600 transition-colors">
@@ -115,7 +115,7 @@ export const AnalysisDashboard: React.FC = () => {
                 </div>
 
                 {/* CENTER COLUMN: Spatial Visualizations */}
-                <div className="lg:col-span-6 flex flex-col gap-3 min-h-0">
+                <div className="lg:col-span-3 flex flex-col gap-3 min-h-0">
                     <div className="flex justify-between items-center bg-charcoal-800 border-l-[3px] border-neon-blue rounded-r px-3 py-1.5 shrink-0 shadow-sm">
                         <h3 className="text-xs font-bold text-gray-300 uppercase tracking-widest">Spatial Analysis</h3>
                         <div className="flex gap-1">
@@ -132,7 +132,7 @@ export const AnalysisDashboard: React.FC = () => {
                         </div>
                     </div>
 
-                    <div className="flex-1 grid grid-cols-2 gap-3 min-h-0">
+                    <div className="flex-1 flex flex-col gap-3 min-h-0 overflow-y-auto custom-scrollbar pr-1">
                         <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-2 flex flex-col min-h-[220px] hover:border-gray-600 transition-colors">
                             <h3 className="text-[10px] font-bold text-gray-400 uppercase text-center mb-2 tracking-wider">Frontier (Usable Corners)</h3>
                             <FrontierMap frontiers={metrics.frontiers} boardState={currentBoard} selectedPlayer={selectedPlayer} />
@@ -211,7 +211,7 @@ const FrontierMap: React.FC<{ frontiers: Record<number, { r: number, c: number }
     return (
         <div className="flex-1 flex flex-col min-h-0">
             <div className="flex-1 flex items-center justify-center min-h-0 bg-slate-900 rounded p-[1px]">
-                <div className="grid gap-[1px] w-full h-full max-h-full aspect-square" style={{ gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))` }}>
+                <div className="grid gap-[1px] w-full max-w-full max-h-full aspect-square" style={{ gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))`, gridTemplateRows: `repeat(${size}, minmax(0, 1fr))` }}>
                     {boardState.map((row, r) => row.map((val, c) => {
                         let bg = 'bg-slate-800';
                         let isFrontier = fMap[r][c];
@@ -222,7 +222,7 @@ const FrontierMap: React.FC<{ frontiers: Record<number, { r: number, c: number }
                         } else if (isFrontier) {
                             bg = ['', 'bg-red-400', 'bg-blue-400', 'bg-yellow-300', 'bg-green-400'][selectedPlayer] + ' shadow-[0_0_8px_currentColor]';
                         }
-                        return <div key={`${r}-${c}`} className={`${bg} ${isFrontier ? 'rounded-full scale-75' : 'rounded-sm'} w-full h-full transition-all`} />
+                        return <div key={`${r}-${c}`} className={`${bg} ${isFrontier ? 'rounded-full scale-75' : 'rounded-sm'} transition-all`} />
                     }))}
                 </div>
             </div>
@@ -237,7 +237,7 @@ const DeadZoneMap: React.FC<{ deadZones: Record<number, boolean[][]>, boardState
     return (
         <div className="flex-1 flex flex-col min-h-0">
             <div className="flex-1 flex items-center justify-center min-h-0 bg-slate-900 rounded p-[1px]">
-                <div className="grid gap-[1px] w-full h-full max-h-full aspect-square" style={{ gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))` }}>
+                <div className="grid gap-[1px] w-full max-w-full max-h-full aspect-square" style={{ gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))`, gridTemplateRows: `repeat(${size}, minmax(0, 1fr))` }}>
                     {boardState.map((row, r) => row.map((val, c) => {
                         let bg = 'bg-slate-800';
                         if (val > 0) {
@@ -250,7 +250,7 @@ const DeadZoneMap: React.FC<{ deadZones: Record<number, boolean[][]>, boardState
                         }
 
                         return (
-                            <div key={`${r}-${c}`} className={`${bg} rounded-sm w-full h-full`}>
+                            <div key={`${r}-${c}`} className={`${bg} rounded-sm`}>
                                 {(val === 0 && dz && dz[r][c]) && (
                                     <svg className="absolute inset-0 w-full h-full opacity-30 pointer-events-none" viewBox="0 0 10 10">
                                         <line x1="0" y1="10" x2="10" y2="0" stroke="#EF4444" strokeWidth="1" />

--- a/frontend/src/components/TelemetryPanel.tsx
+++ b/frontend/src/components/TelemetryPanel.tsx
@@ -1,66 +1,13 @@
-import React, { useState } from 'react';
-import { DebugLogsPanel } from './DebugLogsPanel';
+import React from 'react';
 import { AnalysisDashboard } from './AnalysisDashboard';
 import { ENABLE_DEBUG_UI } from '../constants/gameConstants';
 
-type TelemetrySubTab = 'charts' | 'events';
-
 export const TelemetryPanel: React.FC = () => {
-  const [subTab, setSubTab] = useState<TelemetrySubTab>('charts');
-
   if (!ENABLE_DEBUG_UI) return null;
-
-  if (subTab === 'events') {
-    return (
-      <div className="flex flex-col h-full">
-        <div className="flex gap-1 p-2 border-b border-charcoal-700 shrink-0">
-          <button
-            type="button"
-            onClick={() => setSubTab('charts')}
-            className="flex-1 py-1.5 text-xs rounded bg-charcoal-800 text-gray-400"
-          >
-            Charts / Dashboard
-          </button>
-          <button
-            type="button"
-            onClick={() => setSubTab('events')}
-            className="flex-1 py-1.5 text-xs rounded bg-charcoal-600 text-white"
-          >
-            Events
-          </button>
-        </div>
-        <div className="flex-1 min-h-0">
-          <DebugLogsPanel />
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Controls */}
-      <div className="shrink-0 p-2 border-b border-charcoal-700">
-        <div className="flex flex-wrap gap-2 items-center">
-          <div className="flex gap-1">
-            <button
-              type="button"
-              onClick={() => setSubTab('charts')}
-              className="px-2 py-1 text-xs rounded bg-charcoal-600 text-white"
-            >
-              Charts / Dashboard
-            </button>
-            <button
-              type="button"
-              onClick={() => setSubTab('events')}
-              className="px-2 py-1 text-xs rounded bg-charcoal-800 text-gray-400"
-            >
-              Events
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex-1 p-2 min-h-0 overflow-y-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto">
         <AnalysisDashboard />
       </div>
     </div>


### PR DESCRIPTION
## Overview
This PR addresses crucial bugs in how piece orientations were communicated between the frontend and the Pyodide Web Worker, and restructures the Telemetry Dashboard to better accommodate the predictive charts.

## Changes Included

### 🐛 Bug Fixes: Frontend-Backend Orientation Translation (Web Worker)
*   **The Issue**: The frontend UI cycled through a fixed 8-state index (0-7) for rotations and flips. However, the Blokus engine dynamically deduplicates shapes to optimize generation. This means symmetrical pieces (like the 1-square or a 2x2 square) expected fewer than 8 orientation indices, immediately leading to out-of-bounds errors or incorrect shape matching when a player rotated a piece.
*   **The Fix**: Implemented a bidirectional translation layer in `browser_python/worker_bridge.py`.
    *   **Inbound**: Translates the frontend's raw 0-7 rotation index to the exact matching `orientation_id` the engine expects based on normalized shape offsets.
    *   **Outbound**: Translates the backend's unique `orientation_id` back to the frontend's 0-7 index for legal move highlights, heatmap overlays, and game history restoration.

### 🎨 Feature: Dashboard Layout Restructuring
*   **Chart Resizing**: Transformed the `FrontierMap` and `DeadZoneMap` cells in `AnalysisDashboard.tsx` into strict squares to match the actual Blokus board aspect ratio.
*   **Layout Adjustments**: Modifed the dashboard layout to place the predictive line charts (Frontier Size and Corner Differential) in a wider 6-column container, providing more horizontal space. The spatial grid components were stacked vertically into a 3-column container alongside them.
*   **Tab Simplification**: Removed the redundant "Events" and "Charts / Dashboard" sub-tabs inside `TelemetryPanel.tsx`. Selecting the main "Dashboard" tab now immediately renders the Analysis Dashboard.
*   **Strategy Documentation**: Created a detailed `strategy_metrics.md` guide documenting the calculated metrics and outlining potential new MCTS agent "personalities" (e.g., Expansionist, Survivor, Aggressor).

## How to Test
1.  Start a fresh Local WebWorker game.
2.  Pick up an asymmetrical piece (like Piece #9 or #10). Rotate (`R`) and Flip (`F`) the piece.
3.  Attempt to place the piece on valid anchor points. Confirm placement succeeds without the previous Warning #9 or #10 console messages, and that the piece visually matches what you placed.
4.  Navigate to the `Dashboard` tab next to `Game` and observe the new, streamlined view with square spatial grides and wider predictive charts.