### PR TITLE
Add extended rollout arena config and Claude guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md — Project Guidelines for Claude Code
+
+## Agent Selection
+
+- **Do NOT use `fast_mcts` (FastMCTSAgent / GameplayFastMCTSAgent) unless the user explicitly asks for it.**
+  The fast_mcts agent uses a simplified rollout policy and lightweight node structure that trades accuracy for speed. Layer 2 analysis found that the evaluation function underperforms under the constrained search time of fast_mcts. Default to the full `mcts` agent type (MCTSAgent) for arena runs and testing.
+
+- When creating new arena configs, prefer `"type": "mcts"` over `"type": "gameplay_fast_mcts"` or `"type": "fast_mcts"`.
+
+## Running Arena Tests
+
+```bash
+# Standard arena run
+python scripts/arena.py --config scripts/arena_config.json
+
+# Extended rollout test (4x rollout, fewer games)
+python scripts/arena.py --config scripts/arena_config_extended_rollout.json
+
+# Smoke test with reduced games
+python scripts/arena.py --config scripts/arena_config_extended_rollout.json --num-games 4
+```
+
+## Key MCTS Parameters
+
+- `max_rollout_moves`: Controls rollout simulation length (default: 50). The extended rollout config uses 200 (4x).
+- `iterations`: Max MCTS iterations per move (default: 1000 for full MCTS).
+- `iterations_per_ms`: Conversion rate for deterministic time budgets (10.0 for full MCTS, 20.0 for fast_mcts).
+- `exploration_constant`: UCB1 exploration parameter (default: 1.414).
+
+## Project Structure
+
+- `mcts/mcts_agent.py` — Full MCTSAgent with configurable rollout length
+- `agents/fast_mcts_agent.py` — Lightweight FastMCTSAgent (use only when explicitly requested)
+- `scripts/arena.py` — Arena CLI entry point
+- `scripts/arena_config*.json` — Arena configuration files
+- `analytics/tournament/arena_runner.py` — Arena harness and agent construction

--- a/scripts/arena_config_extended_rollout.json
+++ b/scripts/arena_config_extended_rollout.json
@@ -1,0 +1,63 @@
+{
+  "agents": [
+    {
+      "name": "mcts_100ms_4x_rollout",
+      "type": "mcts",
+      "thinking_time_ms": 100,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations": 1000,
+        "iterations_per_ms": 10.0,
+        "exploration_constant": 1.414,
+        "max_rollout_moves": 200
+      }
+    },
+    {
+      "name": "mcts_200ms_4x_rollout",
+      "type": "mcts",
+      "thinking_time_ms": 200,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations": 1000,
+        "iterations_per_ms": 10.0,
+        "exploration_constant": 1.414,
+        "max_rollout_moves": 200
+      }
+    },
+    {
+      "name": "mcts_100ms_baseline",
+      "type": "mcts",
+      "thinking_time_ms": 100,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations": 1000,
+        "iterations_per_ms": 10.0,
+        "exploration_constant": 1.414,
+        "max_rollout_moves": 50
+      }
+    },
+    {
+      "name": "mcts_200ms_baseline",
+      "type": "mcts",
+      "thinking_time_ms": 200,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations": 1000,
+        "iterations_per_ms": 10.0,
+        "exploration_constant": 1.414,
+        "max_rollout_moves": 50
+      }
+    }
+  ],
+  "num_games": 25,
+  "seed": 20260323,
+  "seat_policy": "round_robin",
+  "output_root": "arena_runs",
+  "max_turns": 2500,
+  "snapshots": {
+    "enabled": true,
+    "strategy": "fixed_ply",
+    "checkpoints": [8, 16, 24, 32, 40, 48, 56, 64]
+  },
+  "notes": "Layer 2 extended rollout test: 4x rollout length (200 vs 50 moves) using full MCTS agent to evaluate impact of longer rollouts on play quality"
+}


### PR DESCRIPTION
## Summary
This PR adds configuration and documentation for extended rollout testing in the MCTS arena, along with project guidelines for Claude code generation.

## Key Changes

- **New arena configuration** (`arena_config_extended_rollout.json`): Introduces a test configuration comparing MCTS agents with 4x extended rollout length (200 moves vs. 50 baseline) across two thinking time budgets (100ms and 200ms). Includes 25 games with fixed-ply snapshot checkpoints for detailed analysis.

- **Project guidelines** (`CLAUDE.md`): Documents best practices for code generation:
  - Establishes preference for full `mcts` agent type over `fast_mcts` for arena runs and testing, based on Layer 2 analysis findings
  - Provides standard commands for running arena tests (standard, extended rollout, and smoke test variants)
  - Documents key MCTS parameters and their effects
  - Maps project structure for reference

## Implementation Details

The extended rollout configuration enables evaluation of rollout simulation depth impact on play quality. The baseline agents use `max_rollout_moves: 50` while the extended variants use `max_rollout_moves: 200`, allowing direct comparison of how deeper simulations affect agent performance under identical time constraints.

The guidelines codify the decision to default to the full MCTS agent (which provides better evaluation accuracy) rather than the lightweight fast_mcts variant, with explicit opt-out only when explicitly requested by users.

https://claude.ai/code/session_011f9cZpn4f7UKA5VMko58H8