### PR TITLE
Fix evaluation bugs: correct default weights and add center_proximity

### DIFF
--- a/data/layer6_calibrated_weights.json
+++ b/data/layer6_calibrated_weights.json
@@ -6,6 +6,7 @@
     "reachable_empty_squares": 0.08109693693246343,
     "largest_remaining_piece_size": -0.23120837257261234,
     "opponent_avg_mobility": -0.3,
+    "center_proximity": 0.0,
     "territory_enclosure_area": 0.0
   },
   "phase_weights": {
@@ -16,6 +17,7 @@
       "reachable_empty_squares": 0.0,
       "largest_remaining_piece_size": 0.0,
       "opponent_avg_mobility": -0.05287834609528694,
+      "center_proximity": 0.0,
       "territory_enclosure_area": 0.0
     },
     "mid": {
@@ -25,6 +27,7 @@
       "reachable_empty_squares": 0.22774497158891033,
       "largest_remaining_piece_size": -0.238473591231953,
       "opponent_avg_mobility": -0.20277351241243552,
+      "center_proximity": 0.0,
       "territory_enclosure_area": 0.0
     },
     "late": {
@@ -34,6 +37,7 @@
       "reachable_empty_squares": 0.13361753070802862,
       "largest_remaining_piece_size": -0.08518919739412929,
       "opponent_avg_mobility": -0.06278383996091268,
+      "center_proximity": 0.0,
       "territory_enclosure_area": 0.0
     }
   },
@@ -44,6 +48,7 @@
     "reachable_empty_squares": 0.1,
     "largest_remaining_piece_size": 0.1,
     "opponent_avg_mobility": -0.1,
+    "center_proximity": 0.0,
     "territory_enclosure_area": 0.0
   }
 }

--- a/mcts/state_evaluator.py
+++ b/mcts/state_evaluator.py
@@ -53,18 +53,21 @@ _PLAYERS = list(Player)
 # ---------------------------------------------------------------------------
 
 DEFAULT_WEIGHTS: Dict[str, float] = {
-    "squares_placed": 0.30,
-    "remaining_piece_area": -0.15,
-    "accessible_corners": 0.25,
-    "reachable_empty_squares": 0.10,
-    "largest_remaining_piece_size": 0.10,
-    "opponent_avg_mobility": -0.10,
+    "squares_placed": 0.03,
+    "remaining_piece_area": -0.03,
+    "accessible_corners": 0.24,
+    "reachable_empty_squares": 0.08,
+    "largest_remaining_piece_size": -0.23,
+    "opponent_avg_mobility": -0.30,
+    "center_proximity": 0.25,
     "territory_enclosure_area": 0.00,  # placeholder — too expensive for per-step eval
 }
 
 # Normalization constants
 _MAX_FRONTIER = 40.0  # reasonable upper bound for frontier cells
 _MAX_REACHABLE = 60.0  # bounded BFS limit
+_CENTER = 9.5  # board center coordinate (20x20 grid, indices 0-19)
+_MAX_CENTER_DIST = 19.0  # max Manhattan distance from center: |0-9.5|+|0-9.5|
 
 
 FEATURE_NAMES = [
@@ -74,6 +77,7 @@ FEATURE_NAMES = [
     "reachable_empty_squares",
     "largest_remaining_piece_size",
     "opponent_avg_mobility",
+    "center_proximity",
     "territory_enclosure_area",
 ]
 
@@ -133,7 +137,8 @@ class BlokusStateEvaluator:
         """
         pieces_used = board.player_pieces_used[player]
 
-        squares = float(np.sum(board.grid == player.value))
+        player_mask = board.grid == player.value
+        squares = float(np.sum(player_mask))
         f_squares = squares / max(self._total_piece_area, 1)
 
         remaining = sum(
@@ -162,6 +167,16 @@ class BlokusStateEvaluator:
             (opp_frontier_sum / max(opp_count, 1)) / _MAX_FRONTIER, 1.0
         )
 
+        # center_proximity: 1 = pieces clustered at center, 0 = at edges
+        if squares > 0:
+            coords = np.argwhere(player_mask)
+            mean_dist = float(
+                np.mean(np.abs(coords[:, 0] - _CENTER) + np.abs(coords[:, 1] - _CENTER))
+            )
+            f_center = 1.0 - mean_dist / _MAX_CENTER_DIST
+        else:
+            f_center = 0.0
+
         f_territory = 0.0
 
         return {
@@ -171,6 +186,7 @@ class BlokusStateEvaluator:
             "reachable_empty_squares": f_reachable,
             "largest_remaining_piece_size": f_largest,
             "opponent_avg_mobility": f_opp_mobility,
+            "center_proximity": f_center,
             "territory_enclosure_area": f_territory,
         }
 

--- a/tests/test_layer6_eval_refinement.py
+++ b/tests/test_layer6_eval_refinement.py
@@ -112,7 +112,7 @@ class TestFeatureExtraction:
     def test_extract_features_returns_all_seven(self, evaluator, fresh_board):
         features = evaluator.extract_features(fresh_board, Player.RED)
         assert set(features.keys()) == set(FEATURE_NAMES)
-        assert len(features) == 7
+        assert len(features) == 8
 
     def test_extract_features_values_normalised(self, evaluator, fresh_board):
         features = evaluator.extract_features(fresh_board, Player.RED)
@@ -122,7 +122,7 @@ class TestFeatureExtraction:
     def test_extract_features_mid_game(self, evaluator, mid_game_board):
         for player in Player:
             features = evaluator.extract_features(mid_game_board, player)
-            assert len(features) == 7
+            assert len(features) == 8
             for val in features.values():
                 assert 0.0 <= val <= 1.0
 


### PR DESCRIPTION
## Summary

- **Fix default weight miscalibrations** in `BlokusStateEvaluator`: corrects `largest_remaining_piece_size` sign error (+0.10 → -0.23), `squares_placed` 10x overweight (0.30 → 0.03), and `opponent_avg_mobility` 3x underweight (-0.10 → -0.30), per L6 regression analysis
- **Add `center_proximity` feature** — the #1 Random Forest feature (36.1% importance) that was entirely missing from the evaluator. Computes mean Manhattan distance of player's squares to board center, normalized to [0, 1]
- **Update calibrated weights JSON** with `center_proximity` placeholder (0.0) across all weight configs so phase-dependent evaluation doesn't silently ignore it

## Test plan

- [x] All 12 `test_layer6_eval_refinement.py` tests pass (feature count assertions updated 7 → 8)
- [x] Manual verification: `center_proximity` = 0.0 on empty board, ~0.95 for pieces near center
- [x] `DEFAULT_WEIGHTS["largest_remaining_piece_size"] < 0` confirms sign fix
- [ ] Run full arena smoke test: `python3 scripts/arena.py --config scripts/arena_config.json --num-games 1`

https://claude.ai/code/session_01NtaPPZFEKV64NmMtPS3guo