### PR TITLE
Migrate legacy configs from gameplay_fast_mcts to full mcts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ Aggregated from Layers 0–9 PR reports. Last updated: 2026-03-23.
 | Layer | What | Arena Results? |
 |-------|------|---------------|
 | L0 | Measurement infrastructure (profiler, TrueSkill, tournament runner) | N/A (foundation) |
-| L1 | Baseline characterization (571 self-play + 119 heuristic games) | Done — MCTS hurts by 8pts vs heuristic, 11% utilization, peak BF=534 |
+| L1 | Baseline characterization (571 self-play + 119 heuristic games) | **Invalid** — used `gameplay_fast_mcts` (no real rollout), not full MCTS. Needs re-run. |
 | L2 | Learned evaluation model (GBT on 11,604 snapshots) | Done — zero benefit, inference cost (~26ms) eats 200ms budget |
 | L3 | Action reduction (progressive widening + progressive history) | 8-game smoke test only — +19.2 avg score, needs full validation |
 | L4 | Simulation strategy (two-ply, cutoff, minimax backups) | **None** |

--- a/scripts/arena_config.json
+++ b/scripts/arena_config.json
@@ -2,45 +2,41 @@
   "agents": [
     {
       "name": "mcts_25ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 25,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     },
     {
       "name": "mcts_50ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 50,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     },
     {
       "name": "mcts_100ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     },
     {
       "name": "mcts_200ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 200,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     }

--- a/scripts/arena_config_fair_time.json
+++ b/scripts/arena_config_fair_time.json
@@ -2,45 +2,41 @@
   "agents": [
     {
       "name": "mcts_25ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     },
     {
       "name": "mcts_50ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     },
     {
       "name": "mcts_100ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     },
     {
       "name": "mcts_200ms",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414
       }
     }

--- a/scripts/layer1_selfplay_config.json
+++ b/scripts/layer1_selfplay_config.json
@@ -2,48 +2,44 @@
   "agents": [
     {
       "name": "mcts_a",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414,
         "enable_diagnostics": true
       }
     },
     {
       "name": "mcts_b",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414,
         "enable_diagnostics": true
       }
     },
     {
       "name": "mcts_c",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414,
         "enable_diagnostics": true
       }
     },
     {
       "name": "mcts_d",
-      "type": "gameplay_fast_mcts",
+      "type": "mcts",
       "thinking_time_ms": 100,
       "params": {
         "deterministic_time_budget": true,
-        "iterations": 5000,
-        "iterations_per_ms": 20.0,
+        "iterations_per_ms": 10.0,
         "exploration_constant": 1.414,
         "enable_diagnostics": true
       }


### PR DESCRIPTION
## Summary\n\n- Migrate 3 legacy configs (`arena_config.json`, `arena_config_fair_time.json`, `layer1_selfplay_config.json`) from `gameplay_fast_mcts` to full `mcts` agent type\n- Mark L1 baseline results as invalid in TODO.md\n\n`gameplay_fast_mcts` uses `FastMCTSAgent` which has **no real game simulation** — its \"rollout\" is an O(1) heuristic (`piece_size + center_bonus + noise`), with no board state in the tree and none of the Layer 3–9 features. The L1 finding \"MCTS hurts by -8pts vs heuristic\" was measuring this trivial agent, not actual MCTS.\n\nPer-agent changes:\n- `type`: `gameplay_fast_mcts` → `mcts`\n- `iterations_per_ms`: `20.0` → `10.0` (full MCTS rate)\n- Removed `iterations: 5000` (unused with deterministic time budget)\n\n## Test plan\n\n- [x] All 3 configs validate as valid JSON\n- [x] Zero `gameplay_fast_mcts` references remain in any config file\n- [ ] Smoke-test a config: `python3 scripts/arena.py --config scripts/arena_config.json --num-games 1 --verbose`\n\nhttps://claude.ai/code/session_016L5to2KFwVhcwU4cCYsMMS