### PR TITLE
Sync frontend with MCTS backend: use real MCTSAgent, live arena data, layer config UI

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -70,18 +70,21 @@
 - Interactive Blokus board with piece selection and placement — `frontend/src/components/Board.tsx`
 - MCTS visualization suite: rollout histograms, UCT breakdown, exploration/exploitation charts — `frontend/src/components/mcts-viz/`
 - Move impact panels: waterfall charts, strategy-mix radar, move-delta diverging bars — `frontend/src/components/telemetry/`
-- AI Scoreboard / Benchmark page — `frontend/src/pages/Benchmark.tsx`
+- Advanced MCTS configuration UI with Layer 3-9 parameter controls and layer presets — `frontend/src/components/GameConfigModal.tsx`
+- Arena Results page with live pairwise win rate matrix, TrueSkill ratings, and agent config display — `frontend/src/pages/Benchmark.tsx`
+- Layer Progression dashboard grouping arena experiments by MCTS layer with expandable result cards — `frontend/src/pages/TrainEval.tsx`
 - Analysis page with MCTS diagnostics — `frontend/src/pages/Analysis.tsx`
 - ExplainMove panel — `frontend/src/components/ExplainMovePanel.tsx`
-- Game history browser — `frontend/src/pages/History.tsx`
+- Game history browser with agent config badges and active layer indicators — `frontend/src/pages/History.tsx`
 
 ## Web API
 
 - FastAPI REST backend — `webapi/app.py`
 - Gameplay routes: game creation, moves, state management — `webapi/routes_gameplay.py`
-- Research routes: training runs, analysis, history, trends — `webapi/routes_research.py`
-- Game orchestration manager — `webapi/game_manager.py`
-- Agent factory for dynamic agent instantiation — `webapi/gameplay_agent_factory.py`
+- Research routes: training runs, analysis, history, trends, arena results — `webapi/routes_research.py`
+- Arena results API: list and detail endpoints for tournament data (`/api/arena-runs`) — `webapi/app.py`, `webapi/routes_research.py`
+- Game orchestration with full MCTSAgent (Layers 3-9) — `webapi/app.py`
+- Agent factory using MCTSAgent with gameplay adapter — `webapi/gameplay_agent_factory.py`
 - MongoDB integration — `webapi/db/`
 - Research and deploy profiles — `webapi/profile.py`
 

--- a/frontend/src/components/GameConfigModal.tsx
+++ b/frontend/src/components/GameConfigModal.tsx
@@ -130,6 +130,65 @@ export const GameConfigModal: React.FC<GameConfigModalProps> = ({
     }
   };
 
+  const [expandedAdvanced, setExpandedAdvanced] = useState<number | null>(null);
+
+  const MCTS_LAYER_PRESETS: Record<string, { label: string; description: string; config: Record<string, any> }> = {
+    'baseline': {
+      label: 'Baseline',
+      description: 'Vanilla MCTS (no layers)',
+      config: { time_budget_ms: 1000 },
+    },
+    'layer3': {
+      label: 'L3: Action Reduction',
+      description: 'Progressive widening + history',
+      config: { time_budget_ms: 1000, progressive_widening_enabled: true, pw_c: 2.0, pw_alpha: 0.5, progressive_history_enabled: true },
+    },
+    'layer4': {
+      label: 'L4: Simulation',
+      description: 'Heuristic rollouts + cutoff',
+      config: { time_budget_ms: 1000, progressive_widening_enabled: true, progressive_history_enabled: true, rollout_policy: 'heuristic', rollout_cutoff_depth: 10, minimax_backup_alpha: 0.25 },
+    },
+    'layer5': {
+      label: 'L5: RAVE',
+      description: 'RAVE value estimation',
+      config: { time_budget_ms: 1000, progressive_widening_enabled: true, progressive_history_enabled: true, rollout_policy: 'heuristic', rollout_cutoff_depth: 10, rave_enabled: true, rave_k: 1000 },
+    },
+    'layer7': {
+      label: 'L7: Opponents',
+      description: 'Opponent modeling + alliances',
+      config: { time_budget_ms: 1000, progressive_widening_enabled: true, progressive_history_enabled: true, rollout_policy: 'heuristic', rollout_cutoff_depth: 10, rave_enabled: true, rave_k: 1000, opponent_modeling_enabled: true, alliance_detection_enabled: true, kingmaker_detection_enabled: true },
+    },
+    'layer9': {
+      label: 'L9: Full Stack',
+      description: 'All layers + meta-optimization',
+      config: { time_budget_ms: 1500, progressive_widening_enabled: true, progressive_history_enabled: true, rollout_policy: 'heuristic', rollout_cutoff_depth: 10, minimax_backup_alpha: 0.25, rave_enabled: true, rave_k: 1000, opponent_modeling_enabled: true, alliance_detection_enabled: true, kingmaker_detection_enabled: true, adaptive_exploration_enabled: true, sufficiency_threshold_enabled: true },
+    },
+  };
+
+  const updateAdvancedConfig = (playerIndex: number, key: string, value: any) => {
+    setGameConfig((prev: any) => ({
+      ...prev,
+      players: prev.players.map((p: any, i: number) =>
+        i === playerIndex
+          ? { ...p, agent_config: { ...p.agent_config, [key]: value } }
+          : p
+      ),
+    }));
+  };
+
+  const applyMctsPreset = (playerIndex: number, presetKey: string) => {
+    const preset = MCTS_LAYER_PRESETS[presetKey];
+    if (!preset) return;
+    setGameConfig((prev: any) => ({
+      ...prev,
+      players: prev.players.map((p: any, i: number) =>
+        i === playerIndex
+          ? { ...p, agent_type: 'mcts', agent_config: { ...preset.config } }
+          : p
+      ),
+    }));
+  };
+
   const researchQuickStartPresets = [
     {
       name: '4 Players',
@@ -195,6 +254,19 @@ export const GameConfigModal: React.FC<GameConfigModalProps> = ({
         players: [
           { player: 'RED', agent_type: 'human', agent_config: {} },
           { player: 'BLUE', agent_type: 'mcts', agent_config: { time_budget_ms: 5000 } }
+        ],
+        auto_start: true
+      }
+    },
+    {
+      name: 'Layer Battle',
+      description: 'Baseline vs L3 vs L5 vs L9',
+      config: {
+        players: [
+          { player: 'RED', agent_type: 'mcts', agent_config: { ...MCTS_LAYER_PRESETS.baseline.config } },
+          { player: 'BLUE', agent_type: 'mcts', agent_config: { ...MCTS_LAYER_PRESETS.layer3.config } },
+          { player: 'GREEN', agent_type: 'mcts', agent_config: { ...MCTS_LAYER_PRESETS.layer5.config } },
+          { player: 'YELLOW', agent_type: 'mcts', agent_config: { ...MCTS_LAYER_PRESETS.layer9.config } }
         ],
         auto_start: true
       }
@@ -508,38 +580,222 @@ export const GameConfigModal: React.FC<GameConfigModalProps> = ({
               </label>
               <div className="space-y-3">
                 {gameConfig.players.map((player: any, index: number) => (
-                  <div key={index} className="flex items-center space-x-3">
-                    <div className="w-24">
-                      <select
-                        value={player.player}
-                        onChange={(e) => updatePlayer(index, 'player', e.target.value)}
-                        className="w-full bg-charcoal-900 border border-charcoal-700 text-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-neon-blue"
-                      >
-                        <option value="RED">Red</option>
-                        <option value="BLUE">Blue</option>
-                        <option value="GREEN">Green</option>
-                        <option value="YELLOW">Yellow</option>
-                      </select>
+                  <div key={index} className="space-y-2">
+                    <div className="flex items-center space-x-3">
+                      <div className="w-24">
+                        <select
+                          value={player.player}
+                          onChange={(e) => updatePlayer(index, 'player', e.target.value)}
+                          className="w-full bg-charcoal-900 border border-charcoal-700 text-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-neon-blue"
+                        >
+                          <option value="RED">Red</option>
+                          <option value="BLUE">Blue</option>
+                          <option value="GREEN">Green</option>
+                          <option value="YELLOW">Yellow</option>
+                        </select>
+                      </div>
+                      <div className="flex-1">
+                        <select
+                          value={player.agent_type}
+                          onChange={(e) => updatePlayer(index, 'agent_type', e.target.value)}
+                          className="w-full bg-charcoal-900 border border-charcoal-700 text-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-neon-blue"
+                        >
+                          <option value="human">Human</option>
+                          <option value="random">Random Agent</option>
+                          <option value="heuristic">Heuristic Agent</option>
+                          <option value="mcts">MCTS Agent</option>
+                        </select>
+                      </div>
+                      {player.agent_type === 'mcts' && (
+                        <button
+                          onClick={() => setExpandedAdvanced(expandedAdvanced === index ? null : index)}
+                          className={`text-xs px-2 py-1 rounded border transition-colors ${expandedAdvanced === index ? 'border-neon-blue text-neon-blue bg-neon-blue/10' : 'border-charcoal-600 text-gray-400 hover:text-neon-blue hover:border-neon-blue'}`}
+                          title="Advanced MCTS Settings"
+                        >
+                          Layers
+                        </button>
+                      )}
+                      {gameConfig.players.length > 2 && (
+                        <button
+                          onClick={() => removePlayer(index)}
+                          className="text-red-400 hover:text-red-300 text-sm px-2"
+                        >
+                          Remove
+                        </button>
+                      )}
                     </div>
-                    <div className="flex-1">
-                      <select
-                        value={player.agent_type}
-                        onChange={(e) => updatePlayer(index, 'agent_type', e.target.value)}
-                        className="w-full bg-charcoal-900 border border-charcoal-700 text-gray-200 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-neon-blue"
-                      >
-                        <option value="human">Human</option>
-                        <option value="random">Random Agent</option>
-                        <option value="heuristic">Heuristic Agent</option>
-                        <option value="mcts">MCTS Agent</option>
-                      </select>
-                    </div>
-                    {gameConfig.players.length > 2 && (
-                      <button
-                        onClick={() => removePlayer(index)}
-                        className="text-red-400 hover:text-red-300 text-sm px-2"
-                      >
-                        Remove
-                      </button>
+                    {/* Advanced MCTS Configuration */}
+                    {player.agent_type === 'mcts' && expandedAdvanced === index && (
+                      <div className="ml-4 p-3 bg-charcoal-900 border border-charcoal-700 rounded-lg text-xs space-y-3">
+                        {/* Layer Presets */}
+                        <div>
+                          <label className="block text-gray-400 font-semibold mb-1 uppercase tracking-wider" style={{ fontSize: '10px' }}>Layer Preset</label>
+                          <div className="flex flex-wrap gap-1">
+                            {Object.entries(MCTS_LAYER_PRESETS).map(([key, preset]) => (
+                              <button
+                                key={key}
+                                onClick={() => applyMctsPreset(index, key)}
+                                className="px-2 py-0.5 rounded border border-charcoal-600 text-gray-300 hover:border-neon-blue hover:text-neon-blue transition-colors"
+                                title={preset.description}
+                              >
+                                {preset.label}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                        {/* Time Budget */}
+                        <div className="grid grid-cols-2 gap-2">
+                          <div>
+                            <label className="block text-gray-500 mb-0.5">Time Budget (ms)</label>
+                            <input type="number" min={50} max={10000} step={50}
+                              value={player.agent_config?.time_budget_ms ?? 1000}
+                              onChange={(e) => updateAdvancedConfig(index, 'time_budget_ms', parseInt(e.target.value) || 1000)}
+                              className="w-full bg-charcoal-800 border border-charcoal-600 text-gray-200 rounded px-2 py-1 text-xs" />
+                          </div>
+                          <div>
+                            <label className="block text-gray-500 mb-0.5">Exploration C</label>
+                            <input type="number" min={0} max={5} step={0.1}
+                              value={player.agent_config?.exploration_constant ?? 1.414}
+                              onChange={(e) => updateAdvancedConfig(index, 'exploration_constant', parseFloat(e.target.value) || 1.414)}
+                              className="w-full bg-charcoal-800 border border-charcoal-600 text-gray-200 rounded px-2 py-1 text-xs" />
+                          </div>
+                        </div>
+                        {/* Layer 3: Action Reduction */}
+                        <div>
+                          <div className="text-gray-400 font-semibold uppercase tracking-wider mb-1" style={{ fontSize: '10px' }}>L3: Action Reduction</div>
+                          <div className="flex gap-4">
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.progressive_widening_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'progressive_widening_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Prog. Widening
+                            </label>
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.progressive_history_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'progressive_history_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Prog. History
+                            </label>
+                          </div>
+                        </div>
+                        {/* Layer 4: Simulation */}
+                        <div>
+                          <div className="text-gray-400 font-semibold uppercase tracking-wider mb-1" style={{ fontSize: '10px' }}>L4: Simulation Strategy</div>
+                          <div className="grid grid-cols-3 gap-2">
+                            <div>
+                              <label className="block text-gray-500 mb-0.5">Rollout Policy</label>
+                              <select
+                                value={player.agent_config?.rollout_policy ?? 'heuristic'}
+                                onChange={(e) => updateAdvancedConfig(index, 'rollout_policy', e.target.value)}
+                                className="w-full bg-charcoal-800 border border-charcoal-600 text-gray-200 rounded px-2 py-1 text-xs"
+                              >
+                                <option value="random">Random</option>
+                                <option value="heuristic">Heuristic</option>
+                                <option value="two_ply">Two-Ply</option>
+                              </select>
+                            </div>
+                            <div>
+                              <label className="block text-gray-500 mb-0.5">Cutoff Depth</label>
+                              <input type="number" min={0} max={100} step={5}
+                                value={player.agent_config?.rollout_cutoff_depth ?? ''}
+                                placeholder="None"
+                                onChange={(e) => updateAdvancedConfig(index, 'rollout_cutoff_depth', e.target.value ? parseInt(e.target.value) : null)}
+                                className="w-full bg-charcoal-800 border border-charcoal-600 text-gray-200 rounded px-2 py-1 text-xs" />
+                            </div>
+                            <div>
+                              <label className="block text-gray-500 mb-0.5">Minimax Alpha</label>
+                              <input type="number" min={0} max={1} step={0.05}
+                                value={player.agent_config?.minimax_backup_alpha ?? 0}
+                                onChange={(e) => updateAdvancedConfig(index, 'minimax_backup_alpha', parseFloat(e.target.value) || 0)}
+                                className="w-full bg-charcoal-800 border border-charcoal-600 text-gray-200 rounded px-2 py-1 text-xs" />
+                            </div>
+                          </div>
+                        </div>
+                        {/* Layer 5: RAVE & NST */}
+                        <div>
+                          <div className="text-gray-400 font-semibold uppercase tracking-wider mb-1" style={{ fontSize: '10px' }}>L5: RAVE & History</div>
+                          <div className="flex gap-4 items-end">
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.rave_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'rave_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              RAVE
+                            </label>
+                            {player.agent_config?.rave_enabled && (
+                              <div>
+                                <label className="block text-gray-500 mb-0.5">RAVE k</label>
+                                <input type="number" min={100} max={10000} step={100}
+                                  value={player.agent_config?.rave_k ?? 1000}
+                                  onChange={(e) => updateAdvancedConfig(index, 'rave_k', parseFloat(e.target.value) || 1000)}
+                                  className="w-24 bg-charcoal-800 border border-charcoal-600 text-gray-200 rounded px-2 py-1 text-xs" />
+                              </div>
+                            )}
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.nst_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'nst_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              NST
+                            </label>
+                          </div>
+                        </div>
+                        {/* Layer 7: Opponent Modeling */}
+                        <div>
+                          <div className="text-gray-400 font-semibold uppercase tracking-wider mb-1" style={{ fontSize: '10px' }}>L7: Opponent Modeling</div>
+                          <div className="flex flex-wrap gap-3">
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.opponent_modeling_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'opponent_modeling_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Enabled
+                            </label>
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.alliance_detection_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'alliance_detection_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Alliances
+                            </label>
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.kingmaker_detection_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'kingmaker_detection_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              King-maker
+                            </label>
+                          </div>
+                        </div>
+                        {/* Layer 9: Meta-Optimization */}
+                        <div>
+                          <div className="text-gray-400 font-semibold uppercase tracking-wider mb-1" style={{ fontSize: '10px' }}>L9: Meta-Optimization</div>
+                          <div className="flex flex-wrap gap-3">
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.adaptive_exploration_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'adaptive_exploration_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Adaptive C
+                            </label>
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.sufficiency_threshold_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'sufficiency_threshold_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Sufficiency
+                            </label>
+                            <label className="flex items-center gap-1 text-gray-300">
+                              <input type="checkbox" checked={!!player.agent_config?.loss_avoidance_enabled}
+                                onChange={(e) => updateAdvancedConfig(index, 'loss_avoidance_enabled', e.target.checked)}
+                                className="accent-neon-blue" />
+                              Loss Avoidance
+                            </label>
+                          </div>
+                        </div>
+                        {/* Search Trace */}
+                        <div>
+                          <label className="flex items-center gap-1 text-gray-300">
+                            <input type="checkbox" checked={!!player.agent_config?.enable_search_trace}
+                              onChange={(e) => updateAdvancedConfig(index, 'enable_search_trace', e.target.checked)}
+                              className="accent-neon-blue" />
+                            Enable Search Trace (for MCTS visualization)
+                          </label>
+                        </div>
+                      </div>
                     )}
                   </div>
                 ))}

--- a/frontend/src/pages/Benchmark.tsx
+++ b/frontend/src/pages/Benchmark.tsx
@@ -1,181 +1,403 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_BASE } from '../constants/gameConstants';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+
+interface ArenaRunSummary {
+    run_id: string;
+    notes: string;
+    num_games: number;
+    created_at: string;
+    agent_names: string[];
+    agent_count: number;
+}
+
+interface TrueSkillEntry {
+    agent_id: string;
+    mu: number;
+    sigma: number;
+    conservative: number;
+    rank: number;
+    games_played: number;
+}
+
+interface WinStats {
+    [agent: string]: {
+        games_played: number;
+        outright_wins: number;
+        win_rate: number;
+    };
+}
+
+interface PairwiseMatchup {
+    agent_a: string;
+    agent_b: string;
+    a_beats_b: number;
+    b_beats_a: number;
+    tie: number;
+    total: number;
+}
+
+interface ArenaRunDetail {
+    run_id: string;
+    num_games: number;
+    run_config: {
+        notes?: string;
+        created_at?: string;
+        agents: Array<{
+            name: string;
+            type: string;
+            thinking_time_ms?: number;
+            params: Record<string, any>;
+        }>;
+    };
+    pairwise_matchups: Record<string, PairwiseMatchup>;
+    trueskill_ratings?: {
+        leaderboard: TrueSkillEntry[];
+    };
+    win_stats: WinStats;
+    game_duration_sec?: {
+        mean: number;
+        median: number;
+        min: number;
+        max: number;
+    };
+}
+
+const CHART_COLORS = ['#00F0FF', '#00FF9D', '#FFE600', '#FF4D4D', '#A855F7', '#F97316'];
+
+function getActiveLayers(params: Record<string, any>): string[] {
+    const layers: string[] = [];
+    if (params.progressive_widening_enabled || params.progressive_history_enabled) layers.push('L3');
+    if (params.rollout_policy && params.rollout_policy !== 'random') layers.push('L4');
+    if (params.rollout_cutoff_depth != null) layers.push('L4');
+    if (params.rave_enabled) layers.push('L5');
+    if (params.nst_enabled) layers.push('L5');
+    if (params.state_eval_phase_weights) layers.push('L6');
+    if (params.opponent_modeling_enabled) layers.push('L7');
+    if (params.num_workers && params.num_workers > 1) layers.push('L8');
+    if (params.adaptive_exploration_enabled || params.sufficiency_threshold_enabled) layers.push('L9');
+    return [...new Set(layers)];
+}
 
 export const Benchmark: React.FC = () => {
     const navigate = useNavigate();
+    const [runs, setRuns] = useState<ArenaRunSummary[]>([]);
+    const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+    const [runDetail, setRunDetail] = useState<ArenaRunDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const loadRuns = async () => {
+            try {
+                const resp = await fetch(`${API_BASE}/api/arena-runs`);
+                if (!resp.ok) return;
+                const data = await resp.json();
+                setRuns(data.runs || []);
+                if (data.runs?.length > 0) {
+                    setSelectedRunId(data.runs[0].run_id);
+                }
+            } catch {
+                // API not available
+            } finally {
+                setLoading(false);
+            }
+        };
+        loadRuns();
+    }, []);
+
+    useEffect(() => {
+        if (!selectedRunId) return;
+        const loadDetail = async () => {
+            try {
+                const resp = await fetch(`${API_BASE}/api/arena-runs/${selectedRunId}`);
+                if (!resp.ok) return;
+                setRunDetail(await resp.json());
+            } catch {
+                // API not available
+            }
+        };
+        loadDetail();
+    }, [selectedRunId]);
+
+    const leaderboard = runDetail?.trueskill_ratings?.leaderboard || [];
+    const winStats = runDetail?.win_stats || {};
+    const matchups = runDetail?.pairwise_matchups || {};
+    const agents = runDetail?.run_config?.agents || [];
+    const agentNames = agents.map(a => a.name);
+
+    // Build pairwise matrix
+    const buildMatrix = () => {
+        const matrix: Record<string, Record<string, number | null>> = {};
+        for (const name of agentNames) {
+            matrix[name] = {};
+            for (const other of agentNames) {
+                matrix[name][other] = null;
+            }
+        }
+        for (const m of Object.values(matchups)) {
+            if (m.total > 0) {
+                matrix[m.agent_a][m.agent_b] = Math.round((m.a_beats_b / m.total) * 100);
+                matrix[m.agent_b][m.agent_a] = Math.round((m.b_beats_a / m.total) * 100);
+            }
+        }
+        return matrix;
+    };
+
+    const winRateColor = (pct: number | null) => {
+        if (pct === null) return 'text-gray-600';
+        if (pct >= 70) return 'text-green-400';
+        if (pct >= 50) return 'text-neon-blue';
+        if (pct >= 30) return 'text-yellow-400';
+        return 'text-red-400';
+    };
+
+    const tsData = leaderboard.map((entry, i) => ({
+        name: entry.agent_id.replace(/^mcts_/, ''),
+        mu: Math.round(entry.mu * 10) / 10,
+        conservative: Math.round(entry.conservative * 10) / 10,
+        sigma: Math.round(entry.sigma * 10) / 10,
+        color: CHART_COLORS[i % CHART_COLORS.length],
+    }));
+
+    const winData = Object.entries(winStats).map(([agent, stats], i) => ({
+        name: agent.replace(/^mcts_/, ''),
+        winRate: Math.round(stats.win_rate * 100),
+        wins: stats.outright_wins,
+        games: stats.games_played,
+        color: CHART_COLORS[i % CHART_COLORS.length],
+    })).sort((a, b) => b.winRate - a.winRate);
 
     return (
         <div className="min-h-screen bg-charcoal-900 text-gray-200 p-8">
-            <div className="max-w-4xl mx-auto">
+            <div className="max-w-6xl mx-auto">
+                {/* Header */}
                 <div className="flex items-center justify-between mb-8">
                     <div>
                         <h1 className="text-3xl font-bold text-white flex items-center gap-3">
                             <svg className="w-8 h-8 text-neon-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                             </svg>
-                            AI Comparison Scoreboard
+                            Arena Results
                         </h1>
-                        <p className="text-gray-400 mt-2">Historical benchmark results between agent configurations.</p>
+                        <p className="text-gray-400 mt-2">Tournament results from arena experiments</p>
                     </div>
                     <button
                         onClick={() => navigate('/')}
                         className="px-4 py-2 bg-charcoal-800 border border-charcoal-700 hover:bg-charcoal-700 rounded transition-colors"
                     >
-                        ← Back to Game
+                        Back to Game
                     </button>
                 </div>
 
-                {/* High Level Stats */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-                    <div className="bg-charcoal-800 border border-charcoal-700 p-6 rounded-lg shadow-lg">
-                        <h3 className="text-gray-400 text-sm font-semibold uppercase tracking-wider mb-2">Strongest Agent</h3>
-                        <div className="text-2xl font-bold text-neon-blue">MCTS (800ms)</div>
-                        <div className="text-sm text-green-400 mt-1">↑ 24% Edge over 400ms</div>
-                    </div>
-                    <div className="bg-charcoal-800 border border-charcoal-700 p-6 rounded-lg shadow-lg">
-                        <h3 className="text-gray-400 text-sm font-semibold uppercase tracking-wider mb-2">Avg Match Length</h3>
-                        <div className="text-2xl font-bold text-white">82 Moves</div>
-                        <div className="text-sm text-gray-500 mt-1">Highly contested boards</div>
-                    </div>
-                    <div className="bg-charcoal-800 border border-charcoal-700 p-6 rounded-lg shadow-lg">
-                        <h3 className="text-gray-400 text-sm font-semibold uppercase tracking-wider mb-2">Search Efficiency</h3>
-                        <div className="text-2xl font-bold text-neon-yellow">~45k nodes/sec</div>
-                        <div className="text-sm text-gray-500 mt-1">C++ optimized rollouts</div>
-                    </div>
-                </div>
+                {loading && <div className="text-gray-400 text-center py-12">Loading arena runs...</div>}
 
-                {/* Win Rates Table */}
-                <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg shadow-lg overflow-hidden mb-8">
-                    <div className="p-6 border-b border-charcoal-700">
-                        <h2 className="text-xl font-bold text-white">Win Rate Pairwise Matrix (N=200 games)</h2>
+                {!loading && runs.length === 0 && (
+                    <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-12 text-center">
+                        <div className="text-gray-400 text-lg mb-2">No arena runs found</div>
+                        <div className="text-gray-500 text-sm">Run <code className="text-neon-blue">python scripts/arena.py --config scripts/arena_config.json</code> to generate results</div>
                     </div>
-                    <div className="overflow-x-auto p-4">
-                        <table className="w-full text-left">
-                            <thead>
-                                <tr className="text-gray-500 text-sm border-b border-charcoal-700">
-                                    <th className="py-3 px-4">Agent</th>
-                                    <th className="py-3 px-4">vs Random</th>
-                                    <th className="py-3 px-4">vs Heuristic</th>
-                                    <th className="py-3 px-4">vs MCTS (50ms)</th>
-                                    <th className="py-3 px-4">vs MCTS (200ms)</th>
-                                    <th className="py-3 px-4">vs MCTS (400ms)</th>
-                                </tr>
-                            </thead>
-                            <tbody className="text-sm">
-                                <tr className="border-b border-charcoal-700/50 hover:bg-charcoal-700/30">
-                                    <td className="py-3 px-4 font-semibold text-gray-300">Random</td>
-                                    <td className="py-3 px-4 text-gray-600">—</td>
-                                    <td className="py-3 px-4 text-red-400">0%</td>
-                                    <td className="py-3 px-4 text-red-400">0%</td>
-                                    <td className="py-3 px-4 text-red-400">0%</td>
-                                    <td className="py-3 px-4 text-red-400">0%</td>
-                                </tr>
-                                <tr className="border-b border-charcoal-700/50 hover:bg-charcoal-700/30">
-                                    <td className="py-3 px-4 font-semibold text-gray-300">Heuristic</td>
-                                    <td className="py-3 px-4 text-green-400">100%</td>
-                                    <td className="py-3 px-4 text-gray-600">—</td>
-                                    <td className="py-3 px-4 text-red-400">15%</td>
-                                    <td className="py-3 px-4 text-red-400">2%</td>
-                                    <td className="py-3 px-4 text-red-400">0%</td>
-                                </tr>
-                                <tr className="border-b border-charcoal-700/50 hover:bg-charcoal-700/30">
-                                    <td className="py-3 px-4 font-semibold text-neon-blue">MCTS (50ms)</td>
-                                    <td className="py-3 px-4 text-green-400">100%</td>
-                                    <td className="py-3 px-4 text-green-400">85%</td>
-                                    <td className="py-3 px-4 text-gray-600">—</td>
-                                    <td className="py-3 px-4 text-red-400">24%</td>
-                                    <td className="py-3 px-4 text-red-400">12%</td>
-                                </tr>
-                                <tr className="border-b border-charcoal-700/50 hover:bg-charcoal-700/30">
-                                    <td className="py-3 px-4 font-semibold text-neon-blue">MCTS (200ms)</td>
-                                    <td className="py-3 px-4 text-green-400">100%</td>
-                                    <td className="py-3 px-4 text-green-400">98%</td>
-                                    <td className="py-3 px-4 text-green-400">76%</td>
-                                    <td className="py-3 px-4 text-gray-600">—</td>
-                                    <td className="py-3 px-4 text-red-400">35%</td>
-                                </tr>
-                                <tr className="hover:bg-charcoal-700/30">
-                                    <td className="py-3 px-4 font-semibold text-neon-blue">MCTS (400ms)</td>
-                                    <td className="py-3 px-4 text-green-400">100%</td>
-                                    <td className="py-3 px-4 text-green-400">100%</td>
-                                    <td className="py-3 px-4 text-green-400">88%</td>
-                                    <td className="py-3 px-4 text-green-400">65%</td>
-                                    <td className="py-3 px-4 text-gray-600">—</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                )}
 
-                {/* Elo Rating Board */}
-                <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg shadow-lg overflow-hidden">
-                    <div className="p-6 border-b border-charcoal-700 flex justify-between items-center">
-                        <h2 className="text-xl font-bold text-white">Estimated Elo Ratings</h2>
-                        <span className="text-xs text-gray-500 bg-charcoal-900 px-2 py-1 rounded">Baseline: Random = 1000</span>
-                    </div>
-                    <div className="p-4">
-                        <div className="space-y-4 max-w-2xl mx-auto">
-                            {/* Bars */}
-                            <div>
-                                <div className="flex justify-between text-sm mb-1">
-                                    <span className="font-semibold text-gray-300">MCTS (800ms)</span>
-                                    <span className="text-neon-blue font-mono">~2450</span>
-                                </div>
-                                <div className="w-full bg-charcoal-900 rounded-full h-2.5">
-                                    <div className="bg-neon-blue h-2.5 rounded-full" style={{ width: '95%' }}></div>
-                                </div>
-                            </div>
-                            <div>
-                                <div className="flex justify-between text-sm mb-1">
-                                    <span className="font-semibold text-gray-300">MCTS (400ms)</span>
-                                    <span className="text-neon-blue font-mono">2210</span>
-                                </div>
-                                <div className="w-full bg-charcoal-900 rounded-full h-2.5">
-                                    <div className="bg-neon-blue h-2.5 rounded-full" style={{ width: '85%' }}></div>
-                                </div>
-                            </div>
-                            <div>
-                                <div className="flex justify-between text-sm mb-1">
-                                    <span className="font-semibold text-gray-300">MCTS (200ms)</span>
-                                    <span className="text-neon-blue font-mono">1980</span>
-                                </div>
-                                <div className="w-full bg-charcoal-900 rounded-full h-2.5">
-                                    <div className="bg-neon-blue h-2.5 rounded-full" style={{ width: '75%' }}></div>
-                                </div>
-                            </div>
-                            <div>
-                                <div className="flex justify-between text-sm mb-1">
-                                    <span className="font-semibold text-gray-300">MCTS (50ms)</span>
-                                    <span className="text-neon-blue font-mono">1650</span>
-                                </div>
-                                <div className="w-full bg-charcoal-900 rounded-full h-2.5">
-                                    <div className="bg-neon-blue/70 h-2.5 rounded-full" style={{ width: '55%' }}></div>
-                                </div>
-                            </div>
-                            <div>
-                                <div className="flex justify-between text-sm mb-1">
-                                    <span className="font-semibold text-gray-300">Heuristic</span>
-                                    <span className="text-neon-yellow font-mono">1300</span>
-                                </div>
-                                <div className="w-full bg-charcoal-900 rounded-full h-2.5">
-                                    <div className="bg-neon-yellow h-2.5 rounded-full" style={{ width: '35%' }}></div>
-                                </div>
-                            </div>
-                            <div>
-                                <div className="flex justify-between text-sm mb-1">
-                                    <span className="font-semibold text-gray-300">Random</span>
-                                    <span className="text-gray-500 font-mono">1000</span>
-                                </div>
-                                <div className="w-full bg-charcoal-900 rounded-full h-2.5">
-                                    <div className="bg-gray-600 h-2.5 rounded-full" style={{ width: '15%' }}></div>
-                                </div>
-                            </div>
+                {runs.length > 0 && (
+                    <>
+                        {/* Run Selector */}
+                        <div className="mb-6">
+                            <select
+                                value={selectedRunId || ''}
+                                onChange={(e) => setSelectedRunId(e.target.value)}
+                                className="bg-charcoal-800 border border-charcoal-700 text-gray-200 rounded-lg px-4 py-2 focus:outline-none focus:border-neon-blue"
+                            >
+                                {runs.map(run => (
+                                    <option key={run.run_id} value={run.run_id}>
+                                        {run.run_id} — {run.notes || `${run.agent_count} agents, ${run.num_games} games`}
+                                    </option>
+                                ))}
+                            </select>
                         </div>
-                        <p className="text-xs text-gray-500 mt-6 text-center">
-                            Note: Ratings are estimated locally based on N=200 tournament matches between each pair using Bradley-Terry model semantics.
-                        </p>
-                    </div>
-                </div>
+
+                        {runDetail && (
+                            <>
+                                {/* Run Info */}
+                                <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-4 mb-6">
+                                    <div className="flex items-center justify-between">
+                                        <div>
+                                            {runDetail.run_config.notes && (
+                                                <p className="text-neon-blue font-medium">{runDetail.run_config.notes}</p>
+                                            )}
+                                            <p className="text-gray-500 text-sm mt-1">
+                                                {runDetail.num_games} games | {agents.length} agents | {runDetail.run_config.created_at?.slice(0, 10)}
+                                                {runDetail.game_duration_sec && ` | Avg ${runDetail.game_duration_sec.mean.toFixed(1)}s/game`}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Top Stats */}
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+                                    <div className="bg-charcoal-800 border border-charcoal-700 p-6 rounded-lg">
+                                        <h3 className="text-gray-400 text-sm font-semibold uppercase tracking-wider mb-2">Top Agent</h3>
+                                        <div className="text-2xl font-bold text-neon-blue">
+                                            {leaderboard[0]?.agent_id.replace(/^mcts_/, '') || '-'}
+                                        </div>
+                                        {leaderboard[0] && (
+                                            <div className="text-sm text-green-400 mt-1">
+                                                TrueSkill {leaderboard[0].mu.toFixed(1)} ({leaderboard[0].conservative.toFixed(1)} conservative)
+                                            </div>
+                                        )}
+                                    </div>
+                                    <div className="bg-charcoal-800 border border-charcoal-700 p-6 rounded-lg">
+                                        <h3 className="text-gray-400 text-sm font-semibold uppercase tracking-wider mb-2">Games Played</h3>
+                                        <div className="text-2xl font-bold text-white">{runDetail.num_games}</div>
+                                        <div className="text-sm text-gray-500 mt-1">{Object.keys(matchups).length} matchup pairs</div>
+                                    </div>
+                                    <div className="bg-charcoal-800 border border-charcoal-700 p-6 rounded-lg">
+                                        <h3 className="text-gray-400 text-sm font-semibold uppercase tracking-wider mb-2">Highest Win Rate</h3>
+                                        <div className="text-2xl font-bold text-neon-yellow">
+                                            {winData[0] ? `${winData[0].winRate}%` : '-'}
+                                        </div>
+                                        <div className="text-sm text-gray-500 mt-1">
+                                            {winData[0]?.name || '-'} ({winData[0]?.wins || 0}/{winData[0]?.games || 0} wins)
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* TrueSkill Chart + Win Rate Chart side by side */}
+                                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+                                    {/* TrueSkill Ratings */}
+                                    <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-6">
+                                        <h2 className="text-lg font-bold text-white mb-4">TrueSkill Ratings</h2>
+                                        {tsData.length > 0 ? (
+                                            <ResponsiveContainer width="100%" height={250}>
+                                                <BarChart data={tsData} layout="vertical" margin={{ left: 20 }}>
+                                                    <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                                                    <XAxis type="number" stroke="#666" />
+                                                    <YAxis type="category" dataKey="name" stroke="#999" width={120} tick={{ fontSize: 12 }} />
+                                                    <Tooltip
+                                                        contentStyle={{ backgroundColor: '#252526', border: '1px solid #333', borderRadius: '8px' }}
+                                                        formatter={(value: any, name: any) => [(value ?? 0).toFixed(1), name === 'mu' ? 'Rating (mu)' : 'Conservative']}
+                                                    />
+                                                    <Bar dataKey="mu" name="mu" radius={[0, 4, 4, 0]}>
+                                                        {tsData.map((entry, i) => (
+                                                            <Cell key={i} fill={entry.color} fillOpacity={0.8} />
+                                                        ))}
+                                                    </Bar>
+                                                </BarChart>
+                                            </ResponsiveContainer>
+                                        ) : (
+                                            <div className="text-gray-500 text-center py-8">No TrueSkill data</div>
+                                        )}
+                                    </div>
+
+                                    {/* Win Rates */}
+                                    <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-6">
+                                        <h2 className="text-lg font-bold text-white mb-4">Win Rates</h2>
+                                        {winData.length > 0 ? (
+                                            <ResponsiveContainer width="100%" height={250}>
+                                                <BarChart data={winData} layout="vertical" margin={{ left: 20 }}>
+                                                    <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                                                    <XAxis type="number" domain={[0, 100]} stroke="#666" tickFormatter={(v) => `${v}%`} />
+                                                    <YAxis type="category" dataKey="name" stroke="#999" width={120} tick={{ fontSize: 12 }} />
+                                                    <Tooltip
+                                                        contentStyle={{ backgroundColor: '#252526', border: '1px solid #333', borderRadius: '8px' }}
+                                                        formatter={(value: any) => [`${value ?? 0}%`, 'Win Rate']}
+                                                    />
+                                                    <Bar dataKey="winRate" name="Win Rate" radius={[0, 4, 4, 0]}>
+                                                        {winData.map((entry, i) => (
+                                                            <Cell key={i} fill={entry.color} fillOpacity={0.8} />
+                                                        ))}
+                                                    </Bar>
+                                                </BarChart>
+                                            </ResponsiveContainer>
+                                        ) : (
+                                            <div className="text-gray-500 text-center py-8">No win rate data</div>
+                                        )}
+                                    </div>
+                                </div>
+
+                                {/* Pairwise Win Rate Matrix */}
+                                <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg overflow-hidden mb-8">
+                                    <div className="p-6 border-b border-charcoal-700">
+                                        <h2 className="text-xl font-bold text-white">
+                                            Pairwise Win Rate Matrix (N={runDetail.num_games})
+                                        </h2>
+                                    </div>
+                                    <div className="overflow-x-auto p-4">
+                                        <table className="w-full text-left text-sm">
+                                            <thead>
+                                                <tr className="text-gray-500 border-b border-charcoal-700">
+                                                    <th className="py-3 px-4">Agent</th>
+                                                    {agentNames.map(name => (
+                                                        <th key={name} className="py-3 px-4 font-normal">
+                                                            vs {name.replace(/^mcts_/, '')}
+                                                        </th>
+                                                    ))}
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {agentNames.map(rowAgent => {
+                                                    const matrix = buildMatrix();
+                                                    return (
+                                                        <tr key={rowAgent} className="border-b border-charcoal-700/50 hover:bg-charcoal-700/30">
+                                                            <td className="py-3 px-4 font-semibold text-gray-300">
+                                                                {rowAgent.replace(/^mcts_/, '')}
+                                                            </td>
+                                                            {agentNames.map(colAgent => {
+                                                                const pct = rowAgent === colAgent ? null : matrix[rowAgent]?.[colAgent];
+                                                                return (
+                                                                    <td key={colAgent} className={`py-3 px-4 ${rowAgent === colAgent ? 'text-gray-600' : winRateColor(pct)}`}>
+                                                                        {rowAgent === colAgent ? '—' : pct !== null ? `${pct}%` : '-'}
+                                                                    </td>
+                                                                );
+                                                            })}
+                                                        </tr>
+                                                    );
+                                                })}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                {/* Agent Configurations */}
+                                <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg overflow-hidden">
+                                    <div className="p-6 border-b border-charcoal-700">
+                                        <h2 className="text-xl font-bold text-white">Agent Configurations</h2>
+                                    </div>
+                                    <div className="p-4 space-y-3">
+                                        {agents.map((agent) => {
+                                            const layers = getActiveLayers(agent.params || {});
+                                            return (
+                                                <div key={agent.name} className="bg-charcoal-900 rounded-lg p-4 border border-charcoal-700/50">
+                                                    <div className="flex items-center justify-between mb-2">
+                                                        <span className="font-semibold text-gray-200">{agent.name}</span>
+                                                        <div className="flex gap-1">
+                                                            {layers.length > 0 ? layers.map(l => (
+                                                                <span key={l} className="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-neon-blue/10 text-neon-blue border border-neon-blue/20">
+                                                                    {l}
+                                                                </span>
+                                                            )) : (
+                                                                <span className="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-charcoal-700 text-gray-400">
+                                                                    Baseline
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                    <div className="text-xs text-gray-500 space-x-4">
+                                                        <span>type: {agent.type}</span>
+                                                        {agent.thinking_time_ms && <span>think: {agent.thinking_time_ms}ms</span>}
+                                                        {Object.entries(agent.params || {}).filter(([k, v]) => v !== false && v !== null && k !== 'deterministic_time_budget' && k !== 'iterations_per_ms').map(([k, v]) => (
+                                                            <span key={k}>{k}: {String(v)}</span>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            </>
+                        )}
+                    </>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -2,6 +2,39 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { API_BASE } from '../constants/gameConstants';
 
+function getActiveLayers(cfg: Record<string, any>): string[] {
+  const layers: string[] = [];
+  if (cfg.progressive_widening_enabled || cfg.progressive_history_enabled) layers.push('L3');
+  if ((cfg.rollout_policy && cfg.rollout_policy !== 'random') || cfg.rollout_cutoff_depth != null) layers.push('L4');
+  if (cfg.rave_enabled || cfg.nst_enabled) layers.push('L5');
+  if (cfg.state_eval_phase_weights) layers.push('L6');
+  if (cfg.opponent_modeling_enabled) layers.push('L7');
+  if (cfg.num_workers && cfg.num_workers > 1) layers.push('L8');
+  if (cfg.adaptive_exploration_enabled || cfg.sufficiency_threshold_enabled) layers.push('L9');
+  return [...new Set(layers)];
+}
+
+function AgentBadge({ agentType, agentConfig }: { agentType: string; agentConfig: Record<string, any> }) {
+  if (agentType === 'human') return <span className="text-gray-400">Human</span>;
+  if (agentType === 'random') return <span className="text-gray-500">Random</span>;
+  if (agentType === 'heuristic') return <span className="text-neon-yellow">Heuristic</span>;
+
+  const layers = getActiveLayers(agentConfig || {});
+  const budget = agentConfig?.time_budget_ms;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-neon-blue">MCTS</span>
+      {budget && <span className="text-gray-500 text-[10px]">{budget}ms</span>}
+      {layers.map(l => (
+        <span key={l} className="text-[9px] font-bold px-1 py-0 rounded bg-neon-blue/10 text-neon-blue border border-neon-blue/20">
+          {l}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export const History: React.FC = () => {
   const [games, setGames] = useState<any[]>([]);
 
@@ -30,22 +63,34 @@ export const History: React.FC = () => {
               <tr className="text-left border-b border-charcoal-700">
                 <th className="py-2">Game</th>
                 <th>Winner</th>
+                <th>Players</th>
                 <th>Moves</th>
-                <th>Duration (ms)</th>
-                <th>AI Nodes</th>
+                <th>Duration</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
               {games.map((g) => (
                 <tr key={g.game_id} className="border-b border-charcoal-700/40">
-                  <td className="py-2 font-mono">{g.game_id.slice(0, 8)}</td>
+                  <td className="py-2 font-mono text-xs">{g.game_id.slice(0, 8)}</td>
                   <td>{g.winner || 'NONE'}</td>
+                  <td className="py-2">
+                    {g.players ? (
+                      <div className="flex flex-wrap gap-1">
+                        {g.players.map((p: any, i: number) => (
+                          <span key={i} className="text-xs">
+                            <AgentBadge agentType={p.agent_type} agentConfig={p.agent_config || {}} />
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-gray-500 text-xs">-</span>
+                    )}
+                  </td>
                   <td>{g.move_count}</td>
-                  <td>{g.gameDurationMs}</td>
-                  <td>{g.totalAiNodesEvaluated}</td>
+                  <td>{g.gameDurationMs ? `${(g.gameDurationMs / 1000).toFixed(1)}s` : '-'}</td>
                   <td>
-                    <Link className="text-neon-blue" to={`/analysis/${g.game_id}`}>View analysis</Link>
+                    <Link className="text-neon-blue" to={`/analysis/${g.game_id}`}>Analyze</Link>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/pages/TrainEval.tsx
+++ b/frontend/src/pages/TrainEval.tsx
@@ -1,111 +1,294 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_BASE } from '../constants/gameConstants';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+
+interface ArenaRunSummary {
+  run_id: string;
+  notes: string;
+  num_games: number;
+  created_at: string;
+  agent_names: string[];
+}
+
+interface TrueSkillEntry {
+  agent_id: string;
+  mu: number;
+  sigma: number;
+  conservative: number;
+  rank: number;
+}
+
+interface RunDetail {
+  run_id: string;
+  num_games: number;
+  run_config: {
+    notes?: string;
+    created_at?: string;
+    agents: Array<{ name: string; params: Record<string, any> }>;
+  };
+  win_stats: Record<string, { win_rate: number; outright_wins: number; games_played: number }>;
+  trueskill_ratings?: { leaderboard: TrueSkillEntry[] };
+}
+
+interface LayerGroup {
+  layer: string;
+  title: string;
+  description: string;
+  runs: ArenaRunSummary[];
+}
+
+const LAYER_COLORS = ['#00F0FF', '#00FF9D', '#FFE600', '#FF4D4D', '#A855F7', '#F97316'];
+
+const LAYER_DESCRIPTIONS: Record<string, { title: string; description: string }> = {
+  'Layer 3': {
+    title: 'Action Reduction',
+    description: 'Progressive widening limits branching factor; progressive history biases toward historically successful moves.',
+  },
+  'Layer 4': {
+    title: 'Simulation Strategy',
+    description: 'Heuristic/two-ply rollout policies, rollout cutoff with static evaluation, and minimax backup blending.',
+  },
+  'Layer 5': {
+    title: 'RAVE & History',
+    description: 'Rapid Action Value Estimation bootstraps cold-start nodes; NST biases rollouts using move-pair statistics.',
+  },
+  'Layer 6': {
+    title: 'Evaluation Refinement',
+    description: 'Regression-calibrated weights from 13K+ self-play states, phase-dependent evaluation (early/mid/late).',
+  },
+  'Layer 7': {
+    title: 'Opponent Modeling',
+    description: 'Blocking-rate tracking, alliance detection, king-maker awareness, and adaptive cross-game profiles.',
+  },
+  'Layer 9': {
+    title: 'Meta-Optimization',
+    description: 'Adaptive exploration constant, adaptive rollout depth, UCT sufficiency threshold, loss avoidance.',
+  },
+};
+
+function classifyLayer(notes: string): string {
+  const lower = notes.toLowerCase();
+  if (lower.includes('layer 3')) return 'Layer 3';
+  if (lower.includes('layer 4')) return 'Layer 4';
+  if (lower.includes('layer 5')) return 'Layer 5';
+  if (lower.includes('layer 6')) return 'Layer 6';
+  if (lower.includes('layer 7')) return 'Layer 7';
+  if (lower.includes('layer 8')) return 'Layer 8';
+  if (lower.includes('layer 9')) return 'Layer 9';
+  return 'Other';
+}
+
+function groupByLayer(runs: ArenaRunSummary[]): LayerGroup[] {
+  const groups: Record<string, ArenaRunSummary[]> = {};
+  for (const run of runs) {
+    const layer = classifyLayer(run.notes || '');
+    if (!groups[layer]) groups[layer] = [];
+    groups[layer].push(run);
+  }
+  const order = ['Layer 3', 'Layer 4', 'Layer 5', 'Layer 6', 'Layer 7', 'Layer 8', 'Layer 9', 'Other'];
+  return order
+    .filter(l => groups[l]?.length)
+    .map(layer => ({
+      layer,
+      title: LAYER_DESCRIPTIONS[layer]?.title || layer,
+      description: LAYER_DESCRIPTIONS[layer]?.description || '',
+      runs: groups[layer],
+    }));
+}
+
+const LayerRunCard: React.FC<{ run: ArenaRunSummary }> = ({ run }) => {
+  const [detail, setDetail] = useState<RunDetail | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const load = async () => {
+      try {
+        const resp = await fetch(`${API_BASE}/api/arena-runs/${run.run_id}`);
+        if (resp.ok) setDetail(await resp.json());
+      } catch { /* ignore */ }
+    };
+    load();
+  }, [expanded, run.run_id]);
+
+  const leaderboard = detail?.trueskill_ratings?.leaderboard || [];
+  const winStats = detail?.win_stats || {};
+  const winData = Object.entries(winStats)
+    .map(([agent, stats], i) => ({
+      name: agent.replace(/^mcts_/, ''),
+      winRate: Math.round(stats.win_rate * 100),
+      color: LAYER_COLORS[i % LAYER_COLORS.length],
+    }))
+    .sort((a, b) => b.winRate - a.winRate);
+
+  return (
+    <div className="bg-charcoal-900 border border-charcoal-700/50 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full p-4 text-left flex items-center justify-between hover:bg-charcoal-800/50 transition-colors"
+      >
+        <div>
+          <span className="text-gray-200 font-medium text-sm">{run.notes || run.run_id}</span>
+          <span className="text-gray-500 text-xs ml-3">{run.num_games} games | {run.agent_names.length} agents</span>
+        </div>
+        <svg className={`w-4 h-4 text-gray-500 transition-transform ${expanded ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {expanded && detail && (
+        <div className="px-4 pb-4 space-y-4">
+          {/* Win Rate Chart */}
+          {winData.length > 0 && (
+            <ResponsiveContainer width="100%" height={Math.max(120, winData.length * 40)}>
+              <BarChart data={winData} layout="vertical" margin={{ left: 20 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                <XAxis type="number" domain={[0, 100]} stroke="#666" tickFormatter={(v) => `${v}%`} />
+                <YAxis type="category" dataKey="name" stroke="#999" width={140} tick={{ fontSize: 11 }} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: '#252526', border: '1px solid #333', borderRadius: '8px' }}
+                  formatter={(value: any) => [`${value ?? 0}%`, 'Win Rate']}
+                />
+                <Bar dataKey="winRate" radius={[0, 4, 4, 0]}>
+                  {winData.map((entry, i) => (
+                    <Cell key={i} fill={entry.color} fillOpacity={0.8} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+          {/* TrueSkill Leaderboard */}
+          {leaderboard.length > 0 && (
+            <div className="text-xs">
+              <div className="text-gray-400 font-semibold uppercase tracking-wider mb-2" style={{ fontSize: '10px' }}>
+                TrueSkill Ranking
+              </div>
+              <div className="space-y-1">
+                {leaderboard.map((entry, i) => (
+                  <div key={entry.agent_id} className="flex items-center gap-3">
+                    <span className={`w-5 text-right font-mono ${i === 0 ? 'text-neon-blue' : 'text-gray-500'}`}>#{entry.rank}</span>
+                    <span className="text-gray-300 flex-1">{entry.agent_id.replace(/^mcts_/, '')}</span>
+                    <span className="text-gray-400 font-mono">{entry.mu.toFixed(1)}</span>
+                    <span className="text-gray-600 font-mono text-[10px]">(+/-{entry.sigma.toFixed(1)})</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export const TrainEval: React.FC = () => {
   const navigate = useNavigate();
+  const [runs, setRuns] = useState<ArenaRunSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const resp = await fetch(`${API_BASE}/api/arena-runs`);
+        if (resp.ok) {
+          const data = await resp.json();
+          setRuns(data.runs || []);
+        }
+      } catch { /* ignore */ }
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  const layerGroups = groupByLayer(runs);
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-charcoal-900 text-gray-200">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-4">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-800">Training & Evaluation</h1>
-              <p className="text-sm text-gray-600">
-                Monitor agent performance and training progress
-              </p>
-            </div>
+      <div className="bg-charcoal-800 border-b border-charcoal-700">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Layer Progression</h1>
+            <p className="text-sm text-gray-400">
+              How each MCTS improvement layer impacts performance
+            </p>
+          </div>
+          <div className="flex gap-3">
             <button
-              onClick={() => navigate('/training')}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+              onClick={() => navigate('/benchmark')}
+              className="px-4 py-2 text-sm bg-charcoal-700 border border-charcoal-600 hover:bg-charcoal-600 rounded transition-colors"
             >
-              View Training History
+              Full Benchmark
+            </button>
+            <button
+              onClick={() => navigate('/')}
+              className="px-4 py-2 text-sm bg-charcoal-700 border border-charcoal-600 hover:bg-charcoal-600 rounded transition-colors"
+            >
+              Back to Game
             </button>
           </div>
         </div>
       </div>
 
       {/* Main Content */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          {/* Training Progress */}
-          <div className="bg-white rounded-lg shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">
-              Training Progress
-            </h2>
-            <div className="space-y-4">
-              <div className="text-center py-12 text-gray-500">
-                <div className="text-4xl mb-4">📊</div>
-                <div>Training charts will appear here</div>
-                <div className="text-sm mt-2">
-                  Run evaluation scripts to see performance metrics
-                </div>
-              </div>
+      <div className="max-w-6xl mx-auto px-6 py-8">
+        {loading && <div className="text-gray-400 text-center py-12">Loading layer experiments...</div>}
+
+        {!loading && layerGroups.length === 0 && (
+          <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-12 text-center">
+            <div className="text-gray-400 text-lg mb-2">No arena experiments found</div>
+            <div className="text-gray-500 text-sm">
+              Run arena experiments to see layer-by-layer progression.
+              <br />
+              <code className="text-neon-blue">python scripts/arena.py --config scripts/arena_config.json</code>
             </div>
           </div>
+        )}
 
-          {/* Agent Comparison */}
-          <div className="bg-white rounded-lg shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">
-              Agent Performance
-            </h2>
-            <div className="space-y-4">
-              <div className="text-center py-12 text-gray-500">
-                <div className="text-4xl mb-4">🏆</div>
-                <div>Agent comparison charts will appear here</div>
-                <div className="text-sm mt-2">
-                  Win rates, average scores, and other metrics
-                </div>
+        {/* Layer Narrative */}
+        {layerGroups.length > 0 && (
+          <div className="space-y-8">
+            {/* Overview */}
+            <div className="bg-charcoal-800 border border-charcoal-700 rounded-lg p-6">
+              <h2 className="text-lg font-bold text-white mb-2">The MCTS Improvement Story</h2>
+              <p className="text-gray-400 text-sm">
+                This project builds a competitive Blokus AI through progressive MCTS enhancements.
+                Each layer addresses a specific weakness: Layer 3 tames the branching factor,
+                Layer 4 improves simulation quality, Layer 5 bootstraps cold-start evaluation,
+                Layer 6 calibrates the evaluation function from data, Layer 7 models opponents,
+                and Layer 9 self-tunes parameters at runtime. Below, arena experiments validate
+                each layer's contribution.
+              </p>
+              <div className="flex gap-2 mt-4">
+                {layerGroups.map(g => (
+                  <a key={g.layer} href={`#${g.layer.replace(' ', '-')}`} className="text-xs px-2 py-1 rounded bg-neon-blue/10 text-neon-blue border border-neon-blue/20 hover:bg-neon-blue/20 transition-colors">
+                    {g.layer}: {g.title}
+                  </a>
+                ))}
               </div>
             </div>
-          </div>
 
-          {/* Recent Games */}
-          <div className="bg-white rounded-lg shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">
-              Recent Games
-            </h2>
-            <div className="space-y-4">
-              <div className="text-center py-12 text-gray-500">
-                <div className="text-4xl mb-4">🎮</div>
-                <div>Game history will appear here</div>
-                <div className="text-sm mt-2">
-                  Track game outcomes and agent performance
+            {/* Layer Sections */}
+            {layerGroups.map(group => (
+              <div key={group.layer} id={group.layer.replace(' ', '-')} className="bg-charcoal-800 border border-charcoal-700 rounded-lg overflow-hidden">
+                <div className="p-6 border-b border-charcoal-700">
+                  <div className="flex items-center gap-3 mb-2">
+                    <span className="text-xs font-bold uppercase px-2 py-0.5 rounded bg-neon-blue/10 text-neon-blue border border-neon-blue/20">
+                      {group.layer}
+                    </span>
+                    <h2 className="text-xl font-bold text-white">{group.title}</h2>
+                  </div>
+                  <p className="text-gray-400 text-sm">{group.description}</p>
+                </div>
+                <div className="p-4 space-y-2">
+                  {group.runs.map(run => (
+                    <LayerRunCard key={run.run_id} run={run} />
+                  ))}
                 </div>
               </div>
-            </div>
+            ))}
           </div>
-
-          {/* Evaluation Results */}
-          <div className="bg-white rounded-lg shadow-lg p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">
-              Evaluation Results
-            </h2>
-            <div className="space-y-4">
-              <div className="text-center py-12 text-gray-500">
-                <div className="text-4xl mb-4">📈</div>
-                <div>Evaluation results will appear here</div>
-                <div className="text-sm mt-2">
-                  Detailed performance analysis and statistics
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Instructions */}
-        <div className="mt-8 bg-blue-50 border border-blue-200 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-blue-800 mb-3">
-            How to Use This Page
-          </h3>
-          <div className="text-blue-700 space-y-2">
-            <div>• Run the arena script to generate evaluation data</div>
-            <div>• Use training scripts to monitor learning progress</div>
-            <div>• Charts and metrics will automatically populate</div>
-            <div>• Compare different agent configurations</div>
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/webapi/app.py
+++ b/webapi/app.py
@@ -34,7 +34,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from agents.fast_mcts_agent import FastMCTSAgent
+from mcts.mcts_agent import MCTSAgent
 from agents.heuristic_agent import HeuristicAgent
 from agents.random_agent import RandomAgent
 from engine.board import Player as EnginePlayer
@@ -151,10 +151,58 @@ class GameManager:
                 agents[player] = HeuristicAgent()
             elif agent_type == AgentType.MCTS:
                 budget_ms = int(agent_config.get('time_budget_ms', 1000))
-                agents[player] = FastMCTSAgent(
-                    iterations=5000,
+                cfg = dict(agent_config)
+                agents[player] = MCTSAgent(
+                    iterations=int(cfg.get('iterations', 5000)),
                     time_limit=max(budget_ms, 1) / 1000.0,
-                    exploration_constant=1.414
+                    exploration_constant=float(cfg.get('exploration_constant', 1.414)),
+                    use_transposition_table=bool(cfg.get('use_transposition_table', True)),
+                    max_rollout_moves=int(cfg.get('max_rollout_moves', 50)),
+                    # Layer 3: Action Reduction
+                    progressive_widening_enabled=bool(cfg.get('progressive_widening_enabled', False)),
+                    pw_c=float(cfg.get('pw_c', 2.0)),
+                    pw_alpha=float(cfg.get('pw_alpha', 0.5)),
+                    progressive_history_enabled=bool(cfg.get('progressive_history_enabled', False)),
+                    progressive_history_weight=float(cfg.get('progressive_history_weight', 1.0)),
+                    heuristic_move_ordering=bool(cfg.get('heuristic_move_ordering', False)),
+                    # Layer 4: Simulation Strategy
+                    rollout_policy=str(cfg.get('rollout_policy', 'heuristic')),
+                    two_ply_top_k=int(cfg['two_ply_top_k']) if cfg.get('two_ply_top_k') is not None else None,
+                    rollout_cutoff_depth=int(cfg['rollout_cutoff_depth']) if cfg.get('rollout_cutoff_depth') is not None else None,
+                    state_eval_weights=cfg.get('state_eval_weights'),
+                    state_eval_phase_weights=cfg.get('state_eval_phase_weights'),
+                    minimax_backup_alpha=float(cfg.get('minimax_backup_alpha', 0.0)),
+                    # Layer 5: History Heuristics & RAVE
+                    rave_enabled=bool(cfg.get('rave_enabled', False)),
+                    rave_k=float(cfg.get('rave_k', 1000.0)),
+                    nst_enabled=bool(cfg.get('nst_enabled', False)),
+                    nst_weight=float(cfg.get('nst_weight', 0.5)),
+                    # Layer 7: Opponent Modeling
+                    opponent_rollout_policy=str(cfg.get('opponent_rollout_policy', 'same')),
+                    opponent_modeling_enabled=bool(cfg.get('opponent_modeling_enabled', False)),
+                    alliance_detection_enabled=bool(cfg.get('alliance_detection_enabled', False)),
+                    alliance_threshold=float(cfg.get('alliance_threshold', 2.0)),
+                    kingmaker_detection_enabled=bool(cfg.get('kingmaker_detection_enabled', False)),
+                    kingmaker_score_gap=int(cfg.get('kingmaker_score_gap', 15)),
+                    adaptive_opponent_enabled=bool(cfg.get('adaptive_opponent_enabled', False)),
+                    defensive_weight_shift=float(cfg.get('defensive_weight_shift', 0.15)),
+                    # Layer 8: Parallelization
+                    num_workers=int(cfg.get('num_workers', 1)),
+                    virtual_loss=float(cfg.get('virtual_loss', 1.0)),
+                    parallel_strategy=str(cfg.get('parallel_strategy', 'root')),
+                    # Layer 9: Meta-Optimization
+                    adaptive_exploration_enabled=bool(cfg.get('adaptive_exploration_enabled', False)),
+                    adaptive_exploration_base=float(cfg.get('adaptive_exploration_base', 1.414)),
+                    adaptive_exploration_avg_bf=float(cfg.get('adaptive_exploration_avg_bf', 80.0)),
+                    adaptive_rollout_depth_enabled=bool(cfg.get('adaptive_rollout_depth_enabled', False)),
+                    adaptive_rollout_depth_base=int(cfg.get('adaptive_rollout_depth_base', 20)),
+                    adaptive_rollout_depth_avg_bf=float(cfg.get('adaptive_rollout_depth_avg_bf', 80.0)),
+                    sufficiency_threshold_enabled=bool(cfg.get('sufficiency_threshold_enabled', False)),
+                    loss_avoidance_enabled=bool(cfg.get('loss_avoidance_enabled', False)),
+                    loss_avoidance_threshold=float(cfg.get('loss_avoidance_threshold', -50.0)),
+                    # Search Trace for visualization
+                    enable_search_trace=bool(cfg.get('enable_search_trace', False)),
+                    search_trace_sample_rate=int(cfg.get('search_trace_sample_rate', 10)),
                 )
             elif agent_type == AgentType.HUMAN:
                 agents[player] = None  # Human players don't need agents
@@ -1380,6 +1428,15 @@ async def get_history(limit: int = 20):
         user_moves = [m for m in moves if m.get("isHuman")]
         total_ai_nodes = sum((m.get("stats") or {}).get("nodesEvaluated", 0) for m in ai_moves)
         total_ai_think = sum((m.get("stats") or {}).get("timeSpentMs", 0) for m in ai_moves)
+        config = g.get('config')
+        player_configs = []
+        if config and hasattr(config, 'players'):
+            for pc in config.players:
+                player_configs.append({
+                    "player": pc.player,
+                    "agent_type": pc.agent_type,
+                    "agent_config": pc.agent_config or {},
+                })
         finished.append({
             "game_id": gid,
             "winner": g.get("winner"),
@@ -1389,6 +1446,7 @@ async def get_history(limit: int = 20):
             "avgUserMoveTimeMs": int(sum((m.get("stats") or {}).get("userMoveTimeMs", 0) for m in user_moves) / max(len(user_moves), 1)),
             "totalAiThinkTimeMs": total_ai_think,
             "totalAiNodesEvaluated": total_ai_nodes,
+            "players": player_configs,
         })
     finished.sort(key=lambda x: x.get('finished_at') or datetime.min, reverse=True)
     return {"games": finished[:limit]}
@@ -1649,6 +1707,48 @@ async def general_exception_handler(request, exc):
     )
 
 
+ARENA_RUNS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "arena_runs")
+
+
+async def list_arena_runs():
+    """List all arena runs with summary metadata."""
+    runs = []
+    if not os.path.isdir(ARENA_RUNS_DIR):
+        return {"runs": runs}
+    for entry in sorted(os.listdir(ARENA_RUNS_DIR), reverse=True):
+        summary_path = os.path.join(ARENA_RUNS_DIR, entry, "summary.json")
+        if not os.path.isfile(summary_path):
+            continue
+        try:
+            with open(summary_path, "r") as f:
+                summary = json.load(f)
+            run_config = summary.get("run_config", {})
+            agents = run_config.get("agents", [])
+            runs.append({
+                "run_id": summary.get("run_id", entry),
+                "notes": run_config.get("notes", ""),
+                "num_games": summary.get("num_games", 0),
+                "created_at": run_config.get("created_at", ""),
+                "agent_names": [a.get("name", "") for a in agents],
+                "agent_count": len(agents),
+            })
+        except Exception:
+            continue
+    return {"runs": runs}
+
+
+async def get_arena_run(run_id: str):
+    """Return full summary for a specific arena run."""
+    summary_path = os.path.join(ARENA_RUNS_DIR, run_id, "summary.json")
+    if not os.path.isfile(summary_path):
+        raise HTTPException(status_code=404, detail=f"Arena run '{run_id}' not found")
+    try:
+        with open(summary_path, "r") as f:
+            return json.load(f)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to read arena run: {exc}")
+
+
 def _normalize_profile(profile: Optional[str]) -> str:
     if profile in (APP_PROFILE_RESEARCH, APP_PROFILE_DEPLOY):
         return profile  # type: ignore[return-value]
@@ -1717,6 +1817,8 @@ def create_app(
             get_training_run=get_training_run,
             list_agents=list_agents,
             get_training_run_evaluations=get_training_run_evaluations,
+            list_arena_runs=list_arena_runs,
+            get_arena_run=get_arena_run,
         )
 
     app_instance.add_exception_handler(HTTPException, http_exception_handler)

--- a/webapi/gameplay_agent_factory.py
+++ b/webapi/gameplay_agent_factory.py
@@ -4,11 +4,39 @@ Factory helpers for deploy-mode gameplay agent adapters.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from agents.gameplay_fast_mcts import GameplayFastMCTSAgent
+from mcts.mcts_agent import MCTSAgent
 from agents.gameplay_protocol import GameplayAgentProtocol
+from engine.board import Board, Player
+from engine.move_generator import Move
 from schemas.game_state import AgentType
+
+
+class _MCTSGameplayAdapter:
+    """Wraps MCTSAgent to satisfy the GameplayAgentProtocol (choose_move)."""
+
+    def __init__(self, agent: MCTSAgent):
+        self._agent = agent
+
+    def choose_move(
+        self,
+        board: Board,
+        player: Player,
+        legal_moves: List[Move],
+        budget_ms: int,
+    ) -> Tuple[Optional[Move], Dict[str, Any]]:
+        move = self._agent.select_action(board, player, legal_moves)
+        stats: Dict[str, Any] = {}
+        if hasattr(self._agent, 'get_search_trace'):
+            trace = self._agent.get_search_trace()
+            if trace:
+                stats['searchTrace'] = trace
+        if hasattr(self._agent, 'get_action_info'):
+            info = self._agent.get_action_info()
+            if 'stats' in info:
+                stats.update(info['stats'])
+        return move, stats
 
 
 def build_deploy_gameplay_agent(
@@ -24,11 +52,12 @@ def build_deploy_gameplay_agent(
     if agent_type == AgentType.HUMAN:
         return None
     if agent_type == AgentType.MCTS:
-        return GameplayFastMCTSAgent(
+        agent = MCTSAgent(
             iterations=int(cfg.get("iterations", 5000)),
             exploration_constant=float(cfg.get("exploration_constant", 1.414)),
             seed=cfg.get("seed"),
         )
+        return _MCTSGameplayAdapter(agent)
     raise ValueError(f"Unsupported deploy agent type: {agent_type}")
 
 

--- a/webapi/routes_research.py
+++ b/webapi/routes_research.py
@@ -27,6 +27,8 @@ def register_research_routes(
     get_training_run: AsyncHandler,
     list_agents: AsyncHandler,
     get_training_run_evaluations: AsyncHandler,
+    list_arena_runs: AsyncHandler,
+    get_arena_run: AsyncHandler,
 ) -> None:
     app.add_api_route("/api/health/db", health_check_db, methods=["GET"])
     app.add_api_route("/debug/mongo", mongo_debug, methods=["GET"])
@@ -40,3 +42,5 @@ def register_research_routes(
     app.add_api_route("/api/training-runs/{run_id}", get_training_run, methods=["GET"])
     app.add_api_route("/api/training-runs/agents/list", list_agents, methods=["GET"])
     app.add_api_route("/api/training-runs/{run_id}/evaluations", get_training_run_evaluations, methods=["GET"])
+    app.add_api_route("/api/arena-runs", list_arena_runs, methods=["GET"])
+    app.add_api_route("/api/arena-runs/{run_id}", get_arena_run, methods=["GET"])


### PR DESCRIPTION
The webapi was importing archived/deleted FastMCTSAgent instead of the real
MCTSAgent with Layers 3-9. This commit fixes the agent wiring, adds arena
results API endpoints, and rebuilds the frontend dashboard pages to surface
the project's layered MCTS improvement narrative.

Backend:
- Replace FastMCTSAgent with MCTSAgent in webapi/app.py and gameplay_agent_factory.py
- Forward all Layer 3-9 parameters from frontend agent_config to MCTSAgent
- Add /api/arena-runs and /api/arena-runs/{run_id} endpoints for tournament data
- Include player configs in game history API response

Frontend:
- GameConfigModal: add advanced MCTS settings panel with layer presets (L3-L9)
  and per-parameter controls grouped by layer
- Benchmark page: replace hardcoded fake data with live arena results including
  pairwise win rate matrix, TrueSkill charts, and agent config display
- TrainEval page: repurpose as Layer Progression dashboard grouping arena
  experiments by layer with expandable result cards and charts
- History page: show agent config badges with active layer indicators
- Add "Layer Battle" quick-start preset (Baseline vs L3 vs L5 vs L9)

https://claude.ai/code/session_019k7g15xexTCEzGpbtxgSo9