### PR TITLE
Make gameplay board fill available space

### DIFF
--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -83,8 +83,8 @@ export const Board: React.FC<BoardProps> = ({
     const x = event.clientX - rect.left;
     const y = event.clientY - rect.top;
 
-    const col = Math.floor(x / CELL_SIZE);
-    const row = Math.floor(y / CELL_SIZE);
+    const col = Math.floor((x / rect.width) * BOARD_SIZE);
+    const row = Math.floor((y / rect.height) * BOARD_SIZE);
 
     if (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE) {
       setHoveredCell({ row, col });
@@ -97,8 +97,8 @@ export const Board: React.FC<BoardProps> = ({
   const handleClick = useCallback((event: React.MouseEvent<SVGSVGElement>) => {
     if (!svgRef.current) return;
     const rect = svgRef.current.getBoundingClientRect();
-    const col = Math.floor((event.clientX - rect.left) / CELL_SIZE);
-    const row = Math.floor((event.clientY - rect.top) / CELL_SIZE);
+    const col = Math.floor(((event.clientX - rect.left) / rect.width) * BOARD_SIZE);
+    const row = Math.floor(((event.clientY - rect.top) / rect.height) * BOARD_SIZE);
     if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) return;
 
     if (previewMove) setPreviewMove(null);
@@ -258,15 +258,18 @@ export const Board: React.FC<BoardProps> = ({
   const piecePreview = getPiecePreview();
 
   return (
-    <div className="flex flex-col items-center justify-center h-full bg-transparent">
-      <svg
-        ref={svgRef}
-        width={BOARD_SIZE * CELL_SIZE}
-        height={BOARD_SIZE * CELL_SIZE}
-        className="cursor-crosshair bg-charcoal-900/50"
-        onMouseMove={handleMouseMove}
-        onClick={handleClick}
-      >
+    <div className="flex items-center justify-center h-full w-full bg-transparent">
+      <div className="aspect-square max-h-full max-w-full h-full">
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${BOARD_SIZE * CELL_SIZE} ${BOARD_SIZE * CELL_SIZE}`}
+          preserveAspectRatio="xMidYMid meet"
+          width="100%"
+          height="100%"
+          className="cursor-crosshair bg-charcoal-900/50 block"
+          onMouseMove={handleMouseMove}
+          onClick={handleClick}
+        >
         {/* Grid lines - higher contrast against dark background */}
         {Array.from({ length: BOARD_SIZE + 1 }).map((_, i) => (
           <g key={i}>
@@ -344,7 +347,8 @@ export const Board: React.FC<BoardProps> = ({
             className="pointer-events-none"
           />
         )}
-      </svg>
+        </svg>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -264,7 +264,7 @@ export const Play: React.FC = () => {
   }
 
   return (
-    <div className="fixed h-screen w-screen bg-charcoal-900 flex overflow-hidden pr-4">
+    <div className="fixed h-screen w-screen bg-charcoal-900 flex overflow-hidden pr-2">
       {/* Left Column - PieceTray (collapsible) */}
       {showPieceTray && (
         <aside className="w-80 border-r border-charcoal-700 bg-charcoal-900 flex flex-col overflow-hidden">
@@ -496,7 +496,7 @@ export const Play: React.FC = () => {
         )}
 
         {/* Board Container */}
-        <div className="relative flex-1 flex items-center justify-center overflow-auto">
+        <div className="relative flex-1 flex items-center justify-center overflow-hidden p-2">
           <Board
             onCellClick={handleCellClick}
             onCellHover={handleCellHover}


### PR DESCRIPTION
The 20x20 board SVG was hard-coded to 480x480px (BOARD_SIZE * CELL_SIZE),
leaving large empty margins around it in the Play page. Make the board
responsive so it scales to fill the center column while preserving its
square aspect ratio.

- Board.tsx: wrap the SVG in an `aspect-square max-h-full max-w-full`
  container, switch the SVG to `viewBox` + `width/height="100%"` with
  `preserveAspectRatio="xMidYMid meet"`. Internal coordinates stay at
  BOARD_SIZE * CELL_SIZE so every rect/line/overlay computation is
  unchanged.
- Board.tsx: update click/hover handlers to derive row/col from the
  measured bounding rect ratio instead of the hard-coded CELL_SIZE, so
  selection lands on the correct cell at any rendered size.
- Play.tsx: swap `overflow-auto` to `overflow-hidden` on the board
  container (scrolling no longer needed since the board always fits),
  add slight padding, and tighten the right gutter from `pr-4` to `pr-2`.

https://claude.ai/code/session_01G2y7pMGLeHDX8qWJHZsuAy