### PR TITLE
Expose /story route in deploy profile

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Play />} />
           <Route path="/play" element={<Play />} />
+          <Route path="/story" element={<RecruiterStoryPage />} />
           {!IS_DEPLOY_PROFILE && (
             <>
               <Route path="/train" element={<TrainEval />} />
@@ -27,7 +28,6 @@ function App() {
               <Route path="/benchmark" element={<Benchmark />} />
               <Route path="/history" element={<History />} />
               <Route path="/mcts-analysis" element={<MctsVisualization />} />
-              <Route path="/story" element={<RecruiterStoryPage />} />
             </>
           )}
         </Routes>


### PR DESCRIPTION
The recruiter story page was gated behind !IS_DEPLOY_PROFILE along with research-only routes, which meant the deployed build rendered a blank page at /story. Moving /story out of the gate so it is always routed.