### PR TITLE
Unify matplotlib charts under /story page aesthetic

### DIFF
--- a/analytics/baseline/plots.py
+++ b/analytics/baseline/plots.py
@@ -1,4 +1,9 @@
-"""Shared matplotlib plotting utilities for Layer 1 baseline analyses."""
+"""Shared matplotlib plotting utilities for Layer 1 baseline analyses.
+
+This module now delegates the visual theme to :mod:`analytics.plot_style` so
+all baseline charts match the `/story` page aesthetic (dark charcoal
+background, Inter typography, neon accent palette).
+"""
 
 from __future__ import annotations
 
@@ -10,40 +15,37 @@ import matplotlib
 matplotlib.use("Agg")  # non-interactive backend for headless environments
 import matplotlib.pyplot as plt
 
+from analytics.plot_style import (
+    CHARCOAL_900,
+    TEXT_SECONDARY,
+    apply_lab_style,
+    save_figure,
+)
+
 
 def setup_plot_style() -> None:
-    """Apply a clean, publication-ready plot style."""
-    plt.rcParams.update(
-        {
-            "figure.figsize": (10, 6),
-            "figure.dpi": 150,
-            "axes.grid": True,
-            "axes.spines.top": False,
-            "axes.spines.right": False,
-            "grid.alpha": 0.3,
-            "font.size": 11,
-            "axes.titlesize": 13,
-            "axes.labelsize": 12,
-        }
-    )
+    """Apply the shared LAB theme to all matplotlib output."""
+    apply_lab_style()
+    # Baseline charts historically run a little taller; preserve that framing.
+    plt.rcParams["figure.figsize"] = (10, 6)
 
 
 def save_plot(fig: plt.Figure, path: str | Path) -> None:
-    """Save figure to *path*, creating parent directories as needed."""
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(path, bbox_inches="tight")
-    plt.close(fig)
+    """Save figure to *path* with the LAB background baked in."""
+    save_figure(fig, path, tight=True)
 
 
 def annotate_threshold(
     ax: plt.Axes,
     y_value: float,
     label: str,
-    color: str = "red",
+    color: Optional[str] = None,
     linestyle: str = "--",
 ) -> None:
     """Draw a horizontal threshold line with a text label."""
+    from analytics.plot_style import NEON_RED
+
+    color = color or NEON_RED
     ax.axhline(y=y_value, color=color, linestyle=linestyle, alpha=0.7, linewidth=1)
     ax.text(
         ax.get_xlim()[1],
@@ -61,9 +63,12 @@ def annotate_peak(
     x: float,
     y: float,
     label: str,
-    color: str = "red",
+    color: Optional[str] = None,
 ) -> None:
     """Annotate a peak point on the plot."""
+    from analytics.plot_style import NEON_RED
+
+    color = color or NEON_RED
     ax.annotate(
         label,
         xy=(x, y),

--- a/analytics/heatmap/renderer.py
+++ b/analytics/heatmap/renderer.py
@@ -25,9 +25,21 @@ PLAYER_COLORS = {
 
 PLAYER_NAMES = {1: "Red", 2: "Blue", 3: "Yellow", 4: "Green"}
 
-# Background color matching the mockup dark theme
-BG_COLOR = "#161622"
-GRID_COLOR = "#2a3a4a"
+# Background color — sourced from the shared LAB theme so all charts share
+# a single dark palette (matches frontend/tailwind.config.js charcoal tokens
+# and the /story page aesthetic).
+from analytics.plot_style import (  # noqa: E402  (grouped with module constants)
+    CHARCOAL_900 as _CHARCOAL_900,
+    CHARCOAL_700 as _CHARCOAL_700,
+    apply_lab_style as _apply_lab_style,
+)
+
+BG_COLOR = _CHARCOAL_900
+GRID_COLOR = _CHARCOAL_700
+
+# Ensure matplotlib picks up the Inter typography + neon defaults for heatmap
+# renders. Safe to call at import time — it only mutates rcParams.
+_apply_lab_style()
 
 
 def load_turn_data(path: Path) -> Dict[str, Any]:

--- a/analytics/plot_style.py
+++ b/analytics/plot_style.py
@@ -1,0 +1,234 @@
+"""Shared matplotlib theme for MCTS Laboratory charts.
+
+All matplotlib output should route through this module so the plots match the
+visual language of the `/story` page (Inter typography, charcoal background,
+neon accent palette). Keeping the tokens in one place mirrors the Tailwind
+config in ``frontend/tailwind.config.js``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import matplotlib
+
+matplotlib.use("Agg")  # safe default for headless chart generation
+import matplotlib.pyplot as plt
+from matplotlib import font_manager
+
+# ---------------------------------------------------------------------------
+# Design tokens (mirror frontend/tailwind.config.js and frontend/src/index.css)
+# ---------------------------------------------------------------------------
+
+CHARCOAL_900 = "#1E1E1E"
+CHARCOAL_800 = "#252526"
+CHARCOAL_700 = "#333333"
+CHARCOAL_600 = "#3E3E42"
+
+NEON_BLUE = "#00F0FF"
+NEON_CYAN = "#22D3EE"
+NEON_VIOLET = "#8B5CF6"
+NEON_GREEN = "#00FF9D"
+NEON_RED = "#FF4D4D"
+NEON_YELLOW = "#FFE600"
+
+TEXT_PRIMARY = "#F3F4F6"   # gray-100
+TEXT_SECONDARY = "#CBD5E1"  # slate-300
+TEXT_MUTED = "#94A3B8"     # slate-400
+
+# Default data-series palette — ordered for good contrast when many series are
+# present in a single chart.
+DATA_PALETTE: tuple[str, ...] = (
+    NEON_CYAN,
+    NEON_VIOLET,
+    NEON_GREEN,
+    NEON_YELLOW,
+    NEON_BLUE,
+    NEON_RED,
+)
+
+# Player colors used for Blokus-specific charts (matches the in-app board).
+PLAYER_COLORS: Dict[str, str] = {
+    "RED": NEON_RED,
+    "BLUE": NEON_BLUE,
+    "YELLOW": NEON_YELLOW,
+    "GREEN": NEON_GREEN,
+}
+
+# Background / axis tokens consumed by legacy code paths that imported raw
+# constants directly.
+BG_COLOR = CHARCOAL_900
+PANEL_COLOR = CHARCOAL_800
+GRID_COLOR = CHARCOAL_700
+SPINE_COLOR = CHARCOAL_600
+
+
+# ---------------------------------------------------------------------------
+# Font stack
+# ---------------------------------------------------------------------------
+
+_FONT_STACK: tuple[str, ...] = (
+    "Inter",
+    "Inter Variable",
+    "Helvetica Neue",
+    "Helvetica",
+    "Arial",
+    "DejaVu Sans",
+)
+
+
+def _resolve_font_family() -> list[str]:
+    """Return a font stack with Inter first if installed, else graceful fallbacks."""
+    available = {f.name for f in font_manager.fontManager.ttflist}
+    return [name for name in _FONT_STACK if name in available] or ["DejaVu Sans"]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def apply_lab_style() -> None:
+    """Apply the LAB theme globally via ``rcParams``.
+
+    Safe to call multiple times. Call this once near the top of any script that
+    produces matplotlib output.
+    """
+    family = _resolve_font_family()
+    plt.rcParams.update(
+        {
+            # Typography
+            "font.family": family,
+            "font.size": 11,
+            "axes.titlesize": 14,
+            "axes.titleweight": "600",
+            "axes.labelsize": 12,
+            "axes.labelweight": "500",
+            "legend.fontsize": 10,
+            "xtick.labelsize": 10,
+            "ytick.labelsize": 10,
+            # Surfaces
+            "figure.facecolor": CHARCOAL_900,
+            "axes.facecolor": CHARCOAL_900,
+            "savefig.facecolor": CHARCOAL_900,
+            "savefig.edgecolor": CHARCOAL_900,
+            # Text colors
+            "text.color": TEXT_PRIMARY,
+            "axes.labelcolor": TEXT_PRIMARY,
+            "axes.titlecolor": TEXT_PRIMARY,
+            "xtick.color": TEXT_SECONDARY,
+            "ytick.color": TEXT_SECONDARY,
+            # Spines / grid
+            "axes.edgecolor": SPINE_COLOR,
+            "axes.linewidth": 1.0,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.grid": True,
+            "grid.color": GRID_COLOR,
+            "grid.alpha": 0.45,
+            "grid.linewidth": 0.8,
+            # Legend
+            "legend.facecolor": CHARCOAL_800,
+            "legend.edgecolor": SPINE_COLOR,
+            "legend.labelcolor": TEXT_PRIMARY,
+            "legend.frameon": True,
+            # Line defaults
+            "lines.linewidth": 2.0,
+            "lines.solid_capstyle": "round",
+            # Figure
+            "figure.dpi": 120,
+            "savefig.dpi": 150,
+            "figure.autolayout": False,
+        }
+    )
+    # Cycle data series through the neon palette.
+    plt.rcParams["axes.prop_cycle"] = plt.cycler(color=list(DATA_PALETTE))
+
+
+def style_axes(ax: plt.Axes) -> plt.Axes:
+    """Re-apply LAB styling to an already-created axes (useful for subplots)."""
+    ax.set_facecolor(CHARCOAL_900)
+    ax.tick_params(colors=TEXT_SECONDARY)
+    ax.grid(True, color=GRID_COLOR, alpha=0.45, linewidth=0.8)
+    for name, spine in ax.spines.items():
+        if name in ("top", "right"):
+            spine.set_visible(False)
+        else:
+            spine.set_color(SPINE_COLOR)
+    return ax
+
+
+def style_legend(legend) -> None:
+    """Force-tint an existing legend to LAB colors."""
+    if legend is None:
+        return
+    frame = legend.get_frame()
+    frame.set_facecolor(CHARCOAL_800)
+    frame.set_edgecolor(SPINE_COLOR)
+    for text in legend.get_texts():
+        text.set_color(TEXT_PRIMARY)
+
+
+def save_figure(fig: plt.Figure, path: str | Path, *, tight: bool = True) -> Path:
+    """Save *fig* to *path* with LAB background, creating parents as needed."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if tight:
+        fig.tight_layout()
+    fig.savefig(
+        out,
+        facecolor=fig.get_facecolor() or CHARCOAL_900,
+        edgecolor=CHARCOAL_900,
+        bbox_inches="tight" if tight else None,
+    )
+    plt.close(fig)
+    return out
+
+
+def palette(n: Optional[int] = None) -> tuple[str, ...]:
+    """Return the neon data palette, optionally sliced to *n* entries."""
+    if n is None:
+        return DATA_PALETTE
+    if n <= len(DATA_PALETTE):
+        return DATA_PALETTE[:n]
+    # Repeat the palette if we need more colors than we defined.
+    repeats = (n + len(DATA_PALETTE) - 1) // len(DATA_PALETTE)
+    return (DATA_PALETTE * repeats)[:n]
+
+
+def player_colors(names: Iterable[str]) -> list[str]:
+    """Look up player-specific colors, falling back to the neon palette."""
+    fallback = iter(DATA_PALETTE)
+    resolved: list[str] = []
+    for name in names:
+        resolved.append(PLAYER_COLORS.get(name.upper(), next(fallback, NEON_CYAN)))
+    return resolved
+
+
+__all__ = [
+    "CHARCOAL_900",
+    "CHARCOAL_800",
+    "CHARCOAL_700",
+    "CHARCOAL_600",
+    "NEON_BLUE",
+    "NEON_CYAN",
+    "NEON_VIOLET",
+    "NEON_GREEN",
+    "NEON_RED",
+    "NEON_YELLOW",
+    "TEXT_PRIMARY",
+    "TEXT_SECONDARY",
+    "TEXT_MUTED",
+    "DATA_PALETTE",
+    "PLAYER_COLORS",
+    "BG_COLOR",
+    "PANEL_COLOR",
+    "GRID_COLOR",
+    "SPINE_COLOR",
+    "apply_lab_style",
+    "style_axes",
+    "style_legend",
+    "save_figure",
+    "palette",
+    "player_colors",
+]

--- a/scripts/analyze_layer6_features.py
+++ b/scripts/analyze_layer6_features.py
@@ -181,6 +181,14 @@ def _residual_analysis(
         import matplotlib
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
+        from analytics.plot_style import (
+            NEON_CYAN,
+            NEON_RED,
+            apply_lab_style,
+            save_figure,
+            style_axes,
+        )
+        apply_lab_style()
         has_mpl = True
     except ImportError:
         has_mpl = False
@@ -220,49 +228,45 @@ def _residual_analysis(
 
         # 1. Residuals vs board occupancy
         fig, ax = plt.subplots(figsize=(10, 6))
-        ax.scatter(occ, residuals, alpha=0.15, s=8)
-        ax.axhline(0, color="red", linestyle="--", linewidth=0.8)
+        style_axes(ax)
+        ax.scatter(occ, residuals, alpha=0.35, s=10, color=NEON_CYAN)
+        ax.axhline(0, color=NEON_RED, linestyle="--", linewidth=0.9)
         ax.set_xlabel("Board Occupancy")
         ax.set_ylabel("Residual (actual - predicted)")
         ax.set_title("Residuals vs Board Occupancy")
-        fig.tight_layout()
-        fig.savefig(str(plot_dir / "residuals_vs_occupancy.png"), dpi=150)
-        plt.close(fig)
+        save_figure(fig, plot_dir / "residuals_vs_occupancy.png")
 
         # 2. Residuals vs turn index
         if turn is not None:
             fig, ax = plt.subplots(figsize=(10, 6))
-            ax.scatter(turn, residuals, alpha=0.15, s=8)
-            ax.axhline(0, color="red", linestyle="--", linewidth=0.8)
+            style_axes(ax)
+            ax.scatter(turn, residuals, alpha=0.35, s=10, color=NEON_CYAN)
+            ax.axhline(0, color=NEON_RED, linestyle="--", linewidth=0.9)
             ax.set_xlabel("Turn Index")
             ax.set_ylabel("Residual")
             ax.set_title("Residuals vs Turn Index")
-            fig.tight_layout()
-            fig.savefig(str(plot_dir / "residuals_vs_turn.png"), dpi=150)
-            plt.close(fig)
+            save_figure(fig, plot_dir / "residuals_vs_turn.png")
 
         # 3. Residuals vs score difference
         fig, ax = plt.subplots(figsize=(10, 6))
-        ax.scatter(score_diff, residuals, alpha=0.15, s=8)
-        ax.axhline(0, color="red", linestyle="--", linewidth=0.8)
+        style_axes(ax)
+        ax.scatter(score_diff, residuals, alpha=0.35, s=10, color=NEON_CYAN)
+        ax.axhline(0, color=NEON_RED, linestyle="--", linewidth=0.9)
         ax.set_xlabel("Score Difference (from mean)")
         ax.set_ylabel("Residual")
         ax.set_title("Residuals vs Score Difference")
-        fig.tight_layout()
-        fig.savefig(str(plot_dir / "residuals_vs_score_diff.png"), dpi=150)
-        plt.close(fig)
+        save_figure(fig, plot_dir / "residuals_vs_score_diff.png")
 
         # 4. Predicted vs actual
         fig, ax = plt.subplots(figsize=(8, 8))
-        ax.scatter(predictions, y, alpha=0.15, s=8)
+        style_axes(ax)
+        ax.scatter(predictions, y, alpha=0.35, s=10, color=NEON_CYAN)
         mn, mx = min(predictions.min(), y.min()), max(predictions.max(), y.max())
-        ax.plot([mn, mx], [mn, mx], "r--", linewidth=0.8)
+        ax.plot([mn, mx], [mn, mx], linestyle="--", color=NEON_RED, linewidth=0.9)
         ax.set_xlabel("Predicted Score")
         ax.set_ylabel("Actual Score")
         ax.set_title("Predicted vs Actual Final Score")
-        fig.tight_layout()
-        fig.savefig(str(plot_dir / "predicted_vs_actual.png"), dpi=150)
-        plt.close(fig)
+        save_figure(fig, plot_dir / "predicted_vs_actual.png")
 
         print(f"  Plots saved to {plot_dir}/")
 
@@ -345,6 +349,14 @@ def _plot_feature_importance(
         import matplotlib
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
+        from analytics.plot_style import (
+            NEON_GREEN,
+            NEON_RED,
+            apply_lab_style,
+            save_figure,
+            style_axes,
+        )
+        apply_lab_style()
     except ImportError:
         return
 
@@ -352,16 +364,15 @@ def _plot_feature_importance(
     vals = [c[key] for c in coef_table[:20]]
 
     fig, ax = plt.subplots(figsize=(10, max(6, len(names) * 0.35)))
-    colors = ["#2ecc71" if v >= 0 else "#e74c3c" for v in vals]
+    style_axes(ax)
+    colors = [NEON_GREEN if v >= 0 else NEON_RED for v in vals]
     ax.barh(range(len(names)), vals, color=colors)
     ax.set_yticks(range(len(names)))
     ax.set_yticklabels(names, fontsize=9)
     ax.set_xlabel(key.replace("_", " ").title())
     ax.set_title(title)
     ax.invert_yaxis()
-    fig.tight_layout()
-    fig.savefig(str(filename), dpi=150)
-    plt.close(fig)
+    save_figure(fig, filename)
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +388,8 @@ def _plot_shap_summary(rf_result: Dict, feature_cols: List[str], plot_dir: Path)
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import shap
+        from analytics.plot_style import apply_lab_style, save_figure
+        apply_lab_style()
     except ImportError:
         return
 
@@ -389,8 +402,7 @@ def _plot_shap_summary(rf_result: Dict, feature_cols: List[str], plot_dir: Path)
         max_display=20,
     )
     fig = plt.gcf()
-    fig.tight_layout()
-    fig.savefig(str(plot_dir / "shap_summary.png"), dpi=150, bbox_inches="tight")
+    save_figure(fig, plot_dir / "shap_summary.png", tight=True)
     plt.close("all")
 
 

--- a/scripts/generate_arena_visuals.py
+++ b/scripts/generate_arena_visuals.py
@@ -22,6 +22,18 @@ import matplotlib.patches as mpatches
 import numpy as np
 
 from analytics.baseline.plots import save_plot, setup_plot_style, annotate_threshold
+from analytics.plot_style import (
+    CHARCOAL_800,
+    NEON_BLUE,
+    NEON_CYAN,
+    NEON_GREEN,
+    NEON_RED,
+    NEON_VIOLET,
+    NEON_YELLOW,
+    SPINE_COLOR,
+    TEXT_MUTED,
+    TEXT_SECONDARY,
+)
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -39,26 +51,29 @@ def load_summary(run_dir: Path) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Color palette (consistent across all plots)
+# Color palette — matches frontend /story page neon tokens
 # ---------------------------------------------------------------------------
 LAYER_COLORS = {
-    "L1": "#636363",
-    "L2": "#9e9ac8",
-    "L3": "#8c6d31",
-    "L4": "#4c72b0",
-    "L5": "#55a868",
-    "L6": "#dd8452",
-    "L9": "#c44e52",
+    "L1": TEXT_MUTED,
+    "L2": NEON_VIOLET,
+    "L3": NEON_YELLOW,
+    "L4": NEON_BLUE,
+    "L5": NEON_GREEN,
+    "L6": NEON_CYAN,
+    "L9": NEON_RED,
 }
 
 AGENT_PALETTE = [
-    "#2b83ba",  # blue
-    "#abdda4",  # green
-    "#fdae61",  # orange
-    "#d7191c",  # red
-    "#756bb1",  # purple
-    "#66c2a5",  # teal
+    NEON_CYAN,
+    NEON_GREEN,
+    NEON_YELLOW,
+    NEON_RED,
+    NEON_VIOLET,
+    NEON_BLUE,
 ]
+
+# Default edge color for bars — subtle charcoal so neon fills pop on dark bg.
+BAR_EDGE = SPINE_COLOR
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +98,7 @@ def _bar_chart(
         colors = AGENT_PALETTE[: len(agents)]
 
     best_idx = values.index(max(values)) if highlight_best else -1
-    edge_colors = ["#333333" if i == best_idx else "black" for i in range(len(agents))]
+    edge_colors = [NEON_CYAN if i == best_idx else BAR_EDGE for i in range(len(agents))]
     linewidths = [2.0 if i == best_idx else 0.5 for i in range(len(agents))]
 
     bars = ax.barh(
@@ -144,16 +159,16 @@ def fig1_layer_progression():
     setup_plot_style()
     fig, ax = plt.subplots(figsize=(12, 7))
 
-    bars = ax.barh(range(len(layers)), win_rates, color=colors, edgecolor="black",
+    bars = ax.barh(range(len(layers)), win_rates, color=colors, edgecolor=BAR_EDGE,
                    linewidth=0.5, height=0.65)
 
     for bar, val in zip(bars, win_rates):
         ax.text(bar.get_width() + 0.01, bar.get_y() + bar.get_height() / 2,
                 f"{val:.0%}", va="center", fontsize=10, fontweight="bold")
 
-    ax.axvline(x=0.25, color="gray", linestyle="--", alpha=0.5, linewidth=1)
+    ax.axvline(x=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6, linewidth=1)
     ax.text(0.25, -0.6, "Random baseline\n(25% = chance)", ha="center",
-            fontsize=8, color="gray")
+            fontsize=8, color=TEXT_MUTED)
 
     ax.set_yticks(range(len(layers)))
     ax.set_yticklabels(layers, fontsize=9)
@@ -200,10 +215,10 @@ def fig2_progressive_widening():
     setup_plot_style()
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
 
-    colors = ["#2ca02c", "#ff7f0e", "#7f7f7f", "#9467bd"]
+    colors = [NEON_GREEN, NEON_YELLOW, TEXT_MUTED, NEON_VIOLET]
 
     # Win rate
-    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars1, win_rates):
         ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                  f"{val:.0%}", ha="center", fontsize=11, fontweight="bold")
@@ -211,11 +226,11 @@ def fig2_progressive_widening():
     ax1.set_xticklabels(labels, fontsize=9, rotation=15, ha="right")
     ax1.set_ylabel("Win Rate")
     ax1.set_title("Win Rate", fontweight="bold")
-    ax1.axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    ax1.axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     ax1.set_ylim(0, 0.8)
 
     # Mean score
-    bars2 = ax2.bar(range(len(labels)), mean_scores, color=colors, edgecolor="black", linewidth=0.5)
+    bars2 = ax2.bar(range(len(labels)), mean_scores, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars2, mean_scores):
         ax2.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.5,
                  f"{val:.1f}", ha="center", fontsize=10)
@@ -228,7 +243,9 @@ def fig2_progressive_widening():
     pairwise_text = "\n".join(f"PW {k}: {v}" for k, v in pw_pairwise.items())
     ax2.text(0.97, 0.95, f"Pairwise H2H:\n{pairwise_text}",
              transform=ax2.transAxes, fontsize=8.5, va="top", ha="right",
-             bbox=dict(boxstyle="round,pad=0.4", facecolor="#e8f5e9", alpha=0.9))
+             color=TEXT_SECONDARY,
+             bbox=dict(boxstyle="round,pad=0.4", facecolor=CHARCOAL_800,
+                       edgecolor=SPINE_COLOR, alpha=0.95))
 
     fig.suptitle("Layer 3: Progressive Widening Dominates Action Reduction",
                  fontsize=14, fontweight="bold", y=1.02)
@@ -261,7 +278,7 @@ def fig3_quality_vs_quantity():
 
     # Win rate bars
     colors = [AGENT_PALETTE[0], AGENT_PALETTE[3], AGENT_PALETTE[2], AGENT_PALETTE[1]]
-    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars1, win_rates):
         ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                  f"{val:.0%}", ha="center", fontsize=11, fontweight="bold")
@@ -269,7 +286,7 @@ def fig3_quality_vs_quantity():
     ax1.set_xticklabels(labels, fontsize=9, rotation=15, ha="right")
     ax1.set_ylabel("Win Rate")
     ax1.set_title("Win Rate: Rollout Quality Beats Quantity", fontweight="bold")
-    ax1.axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    ax1.axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     ax1.set_ylim(0, 0.7)
 
     # Efficiency scatter: ms/move vs win rate
@@ -280,7 +297,7 @@ def fig3_quality_vs_quantity():
     ax2.set_xlabel("Avg ms / move")
     ax2.set_ylabel("Win Rate")
     ax2.set_title("Efficiency: Time vs Win Rate", fontweight="bold")
-    ax2.axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    ax2.axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
 
     fig.suptitle("Layer 4: Rollout Simulation Strategy", fontsize=14, fontweight="bold", y=1.02)
     fig.tight_layout()
@@ -308,7 +325,7 @@ def fig4_rollout_policy():
     colors = [AGENT_PALETTE[0], AGENT_PALETTE[1], AGENT_PALETTE[2], AGENT_PALETTE[3]]
 
     # Win rate
-    bars = axes[0].bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars = axes[0].bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars, win_rates):
         axes[0].text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                      f"{val:.0%}", ha="center", fontsize=10, fontweight="bold")
@@ -316,11 +333,11 @@ def fig4_rollout_policy():
     axes[0].set_xticklabels(labels, fontsize=9, rotation=15, ha="right")
     axes[0].set_ylabel("Win Rate")
     axes[0].set_title("Win Rate", fontweight="bold")
-    axes[0].axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    axes[0].axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     axes[0].set_ylim(0, 0.5)
 
     # Time per move
-    bars2 = axes[1].bar(range(len(labels)), ms_per_move, color=colors, edgecolor="black", linewidth=0.5)
+    bars2 = axes[1].bar(range(len(labels)), ms_per_move, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars2, ms_per_move):
         axes[1].text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 50,
                      f"{val:.0f}ms", ha="center", fontsize=9)
@@ -330,7 +347,7 @@ def fig4_rollout_policy():
     axes[1].set_title("Compute Cost", fontweight="bold")
 
     # Score efficiency
-    bars3 = axes[2].bar(range(len(labels)), score_per_sec, color=colors, edgecolor="black", linewidth=0.5)
+    bars3 = axes[2].bar(range(len(labels)), score_per_sec, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars3, score_per_sec):
         axes[2].text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 1,
                      f"{val:.1f}", ha="center", fontsize=9)
@@ -363,10 +380,10 @@ def fig5_rave_convergence():
     setup_plot_style()
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(13, 5))
 
-    colors = ["#2ca02c", "#98df8a", "#d62728", "#ff9896"]
+    colors = [NEON_GREEN, NEON_CYAN, NEON_RED, NEON_YELLOW]
 
     # Win rate
-    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars1, win_rates):
         ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                  f"{val:.0%}", ha="center", fontsize=11, fontweight="bold")
@@ -374,17 +391,17 @@ def fig5_rave_convergence():
     ax1.set_xticklabels(labels, fontsize=9)
     ax1.set_ylabel("Win Rate")
     ax1.set_title("Win Rate", fontweight="bold")
-    ax1.axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    ax1.axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     ax1.set_ylim(0, 0.5)
 
     # Annotate the key insight
     ax1.annotate("RAVE@50ms beats\nBaseline@200ms!",
                  xy=(0, win_rates[0]), xytext=(1.5, 0.44),
-                 fontsize=10, fontweight="bold", color="#2ca02c",
-                 arrowprops=dict(arrowstyle="->", color="#2ca02c", lw=1.5))
+                 fontsize=10, fontweight="bold", color=NEON_GREEN,
+                 arrowprops=dict(arrowstyle="->", color=NEON_GREEN, lw=1.5))
 
     # Mean score
-    bars2 = ax2.bar(range(len(labels)), mean_scores, color=colors, edgecolor="black", linewidth=0.5)
+    bars2 = ax2.bar(range(len(labels)), mean_scores, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars2, mean_scores):
         ax2.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.3,
                  f"{val:.1f}", ha="center", fontsize=10)
@@ -420,10 +437,10 @@ def fig6_rave_vs_ph():
     setup_plot_style()
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(13, 5))
 
-    colors = ["#2ca02c", "#ff7f0e", "#9467bd", "#7f7f7f"]
+    colors = [NEON_GREEN, NEON_YELLOW, NEON_VIOLET, TEXT_MUTED]
 
     # Win rate
-    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars1, win_rates):
         ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                  f"{val:.1%}", ha="center", fontsize=11, fontweight="bold")
@@ -431,17 +448,17 @@ def fig6_rave_vs_ph():
     ax1.set_xticklabels(labels, fontsize=10)
     ax1.set_ylabel("Win Rate")
     ax1.set_title("Win Rate", fontweight="bold")
-    ax1.axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    ax1.axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     ax1.set_ylim(0, 0.55)
 
     # Draw arrow showing PH hurts RAVE
     ax1.annotate("PH dilutes\nRAVE signal",
                  xy=(1, win_rates[1]), xytext=(2, 0.40),
-                 fontsize=10, fontweight="bold", color="#d62728",
-                 arrowprops=dict(arrowstyle="->", color="#d62728", lw=1.5))
+                 fontsize=10, fontweight="bold", color=NEON_RED,
+                 arrowprops=dict(arrowstyle="->", color=NEON_RED, lw=1.5))
 
     # TrueSkill
-    bars2 = ax2.bar(range(len(labels)), ts_mu, color=colors, edgecolor="black", linewidth=0.5)
+    bars2 = ax2.bar(range(len(labels)), ts_mu, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars2, ts_mu):
         if val is not None:
             ax2.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.3,
@@ -476,10 +493,10 @@ def fig7_evaluation_refinement():
     setup_plot_style()
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(13, 5))
 
-    colors = ["#2b83ba", "#abdda4", "#fdae61", "#d7191c"]
+    colors = [NEON_CYAN, NEON_GREEN, NEON_YELLOW, NEON_RED]
 
     # Win rate
-    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars1 = ax1.bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars1, win_rates):
         ax1.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                  f"{val:.0%}", ha="center", fontsize=11, fontweight="bold")
@@ -492,12 +509,12 @@ def fig7_evaluation_refinement():
     # Add failure annotation
     ax1.annotate("Phase eval: 0% wins\n(inverted early weights,\nmissing center_proximity)",
                  xy=(2.5, 0.01), xytext=(2.5, 0.35),
-                 fontsize=9, color="#d62728", fontweight="bold",
+                 fontsize=9, color=NEON_RED, fontweight="bold",
                  ha="center",
-                 arrowprops=dict(arrowstyle="->", color="#d62728", lw=1.5))
+                 arrowprops=dict(arrowstyle="->", color=NEON_RED, lw=1.5))
 
     # Mean score
-    bars2 = ax2.bar(range(len(labels)), mean_scores, color=colors, edgecolor="black", linewidth=0.5)
+    bars2 = ax2.bar(range(len(labels)), mean_scores, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars2, mean_scores):
         ax2.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.5,
                  f"{val:.1f}", ha="center", fontsize=10)
@@ -536,10 +553,10 @@ def fig8_meta_optimization():
     setup_plot_style()
     fig, axes = plt.subplots(1, 3, figsize=(16, 5.5))
 
-    colors = ["#2ca02c", "#7f7f7f", "#ff7f0e", "#d62728"]
+    colors = [NEON_GREEN, TEXT_MUTED, NEON_YELLOW, NEON_RED]
 
     # Win rate
-    bars1 = axes[0].bar(range(len(labels)), win_rates, color=colors, edgecolor="black", linewidth=0.5)
+    bars1 = axes[0].bar(range(len(labels)), win_rates, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars1, win_rates):
         axes[0].text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.01,
                      f"{val:.0%}", ha="center", fontsize=11, fontweight="bold")
@@ -547,11 +564,11 @@ def fig8_meta_optimization():
     axes[0].set_xticklabels(labels, fontsize=9, rotation=15, ha="right")
     axes[0].set_ylabel("Win Rate")
     axes[0].set_title("Win Rate", fontweight="bold")
-    axes[0].axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    axes[0].axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     axes[0].set_ylim(0, 0.5)
 
     # Speed
-    bars2 = axes[1].bar(range(len(labels)), avg_ms, color=colors, edgecolor="black", linewidth=0.5)
+    bars2 = axes[1].bar(range(len(labels)), avg_ms, color=colors, edgecolor=BAR_EDGE, linewidth=0.5)
     for bar, val in zip(bars2, avg_ms):
         axes[1].text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 30,
                      f"{val:,.0f}ms", ha="center", fontsize=9)
@@ -569,14 +586,14 @@ def fig8_meta_optimization():
     axes[2].set_xlabel("Avg ms / move")
     axes[2].set_ylabel("Win Rate")
     axes[2].set_title("Speed-Quality Tradeoff", fontweight="bold")
-    axes[2].axhline(y=0.25, color="gray", linestyle="--", alpha=0.5)
+    axes[2].axhline(y=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
 
     # Draw arrow for adaptive depth advantage
     axes[2].annotate("Faster AND\nbetter!",
                      xy=(avg_ms[0], win_rates[0]),
                      xytext=(1700, 0.42),
-                     fontsize=10, fontweight="bold", color="#2ca02c",
-                     arrowprops=dict(arrowstyle="->", color="#2ca02c", lw=2))
+                     fontsize=10, fontweight="bold", color=NEON_GREEN,
+                     arrowprops=dict(arrowstyle="->", color=NEON_GREEN, lw=2))
 
     fig.suptitle("Layer 9: Meta-Optimization — Adaptive Depth Wins, Adaptive C Harms",
                  fontsize=13, fontweight="bold", y=1.02)
@@ -611,7 +628,7 @@ def fig9_grand_summary():
     values = [f[1] for f in findings]
     colors = [f[2] for f in findings]
 
-    bars = axes[0].barh(range(len(labels)), values, color=colors, edgecolor="black",
+    bars = axes[0].barh(range(len(labels)), values, color=colors, edgecolor=BAR_EDGE,
                         linewidth=0.5, height=0.7)
     for bar, val in zip(bars, values):
         axes[0].text(bar.get_width() + 0.01, bar.get_y() + bar.get_height() / 2,
@@ -621,7 +638,7 @@ def fig9_grand_summary():
     axes[0].set_xlabel("Best Agent Win Rate")
     axes[0].set_title("Key Findings Across All Layers", fontweight="bold")
     axes[0].invert_yaxis()
-    axes[0].axvline(x=0.25, color="gray", linestyle="--", alpha=0.5)
+    axes[0].axvline(x=0.25, color=TEXT_MUTED, linestyle="--", alpha=0.6)
     axes[0].set_xlim(0, 0.75)
 
     # Panel 2: Recommended configuration evolution
@@ -639,15 +656,15 @@ def fig9_grand_summary():
     x = np.arange(len(config_labels))
     width = 0.35
 
-    bars_eff = axes[1].bar(x - width / 2, efficiency, width, color="#4c72b0",
-                            label="Score / second", edgecolor="black", linewidth=0.5)
+    bars_eff = axes[1].bar(x - width / 2, efficiency, width, color=NEON_CYAN,
+                            label="Score / second", edgecolor=BAR_EDGE, linewidth=0.5)
     ax2_twin = axes[1].twinx()
-    bars_win = ax2_twin.bar(x + width / 2, win_improvement, width, color="#55a868",
-                             label="Best Win Rate", edgecolor="black", linewidth=0.5)
+    bars_win = ax2_twin.bar(x + width / 2, win_improvement, width, color=NEON_GREEN,
+                             label="Best Win Rate", edgecolor=BAR_EDGE, linewidth=0.5)
 
     axes[1].set_xlabel("Configuration Stage")
-    axes[1].set_ylabel("Score / second (efficiency)", color="#4c72b0")
-    ax2_twin.set_ylabel("Best Win Rate", color="#55a868")
+    axes[1].set_ylabel("Score / second (efficiency)", color=NEON_CYAN)
+    ax2_twin.set_ylabel("Best Win Rate", color=NEON_GREEN)
     axes[1].set_xticks(x)
     axes[1].set_xticklabels(config_labels, fontsize=9)
     axes[1].set_title("Efficiency & Strength Through Optimization", fontweight="bold")

--- a/scripts/generate_shap_importance.py
+++ b/scripts/generate_shap_importance.py
@@ -7,6 +7,9 @@ import sys
 from sklearn.inspection import permutation_importance
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from analytics.plot_style import NEON_VIOLET, apply_lab_style, save_figure, style_axes
 
 def generate_importance():
     model_path = PROJECT_ROOT / "models" / "eval_from_overnight.pkl"
@@ -55,22 +58,22 @@ def generate_importance():
     # Sort descending
     df = df.sort_values(by='Importance', ascending=True)
 
-    # We want a nice looking horizontal bar chart
-    plt.style.use('dark_background')  # Looks cool for portfolio
-    plt.figure(figsize=(10, 8))
-    
+    # We want a nice looking horizontal bar chart — LAB theme.
+    apply_lab_style()
+    fig, ax = plt.subplots(figsize=(10, 8))
+    style_axes(ax)
+
     # We only take top 15 features to avoid clutter
     top_df = df.tail(15)
 
-    bars = plt.barh(top_df['Feature'], top_df['Importance'], color='#FF3366', alpha=0.8)
-    
-    plt.xlabel('Permutation Importance', fontsize=12)
-    plt.title('Learned Evaluator: Top 15 Feature Importances', fontsize=16, fontweight='bold', pad=20)
-    plt.tight_layout()
+    ax.barh(top_df['Feature'], top_df['Importance'], color=NEON_VIOLET, alpha=0.9)
+
+    ax.set_xlabel('Permutation Importance')
+    ax.set_title('Learned Evaluator: Top 15 Feature Importances', pad=20)
 
     # Save to docs
     out_path = PROJECT_ROOT / "docs" / "feature_importance.png"
-    plt.savefig(out_path, dpi=300, facecolor='#111111')
+    save_figure(fig, out_path)
     print(f"Successfully saved high-DPI feature importance chart to {out_path}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- New `analytics/plot_style.py` module exposes the `/story` page design tokens (charcoal 900/800/700, neon cyan/violet/green/yellow/blue/red, Inter font stack) plus reusable helpers: `apply_lab_style`, `style_axes`, `style_legend`, `save_figure`, `palette`, `player_colors`.
- `analytics/baseline/plots.py` delegates `setup_plot_style()` to the shared theme, so every baseline analysis script (seat bias, Q-value convergence, iteration efficiency, branching factor, arena visuals) inherits the LAB look for free.
- Existing chart scripts restyled to match the frontend: arena visuals swap muted/desaturated palettes for neon tokens + remove the light `#e8f5e9` annotation box; SHAP importance drops `dark_background` for the shared theme; Layer 6 residual / importance / SHAP plots route through the shared save helpers; heatmap renderer sources `BG_COLOR` / `GRID_COLOR` from the shared tokens and calls `apply_lab_style()` on import.

## Before / After
Before: default matplotlib — white surface, DejaVu serif-ish text, muted palette. After: charcoal-900 surface, Inter typography, neon data series, subtle charcoal grid and legend.

## Test plan
- [x] `python3 -m pytest analytics/tests/` — 7 passed
- [x] Every touched module imports cleanly (`analytics.plot_style`, `analytics.baseline.plots`, `analytics.heatmap.renderer`, `scripts.generate_arena_visuals`, `scripts.generate_shap_importance`, `scripts.analyze_layer6_features`)
- [x] Smoke-rendered a multi-series line chart through `baseline.plots.save_plot` and confirmed charcoal surface + neon cycle + Inter typography render correctly
- [ ] Reviewer: regenerate `arena_visuals/` locally with `python3 scripts/generate_arena_visuals.py` and spot-check `01_layer_progression.png` through `09_grand_summary.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
