### PR TITLE
Fix three piece-placement UX bugs in the Play board

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -68,7 +68,7 @@
 ## Frontend
 
 - React 18 + TypeScript SPA with Zustand state management — `frontend/`
-- Interactive Blokus board with piece selection and placement — `frontend/src/components/Board.tsx`
+- Interactive Blokus board with piece selection and placement (cursor-centered piece preview, optimistic-UI placement, cross-turn pre-selection) — `frontend/src/components/Board.tsx`, `frontend/src/components/PieceTray.tsx`, `frontend/src/utils/pieceUtils.ts`
 - MCTS visualization suite: rollout histograms, UCT breakdown, exploration/exploitation charts — `frontend/src/components/mcts-viz/`
 - Move impact panels: waterfall charts, strategy-mix radar, move-delta diverging bars — `frontend/src/components/telemetry/`
 - Advanced MCTS configuration UI with Layer 3-9 parameter controls and layer presets — `frontend/src/components/GameConfigModal.tsx`

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useGameStore } from '../store/gameStore';
 import { PLAYER_COLORS, BOARD_SIZE, CELL_SIZE } from '../constants/gameConstants';
-import { calculatePiecePositions } from '../utils/pieceUtils';
+import { calculatePiecePositions, getPieceCursorOffset } from '../utils/pieceUtils';
 
 export interface CellOverlay {
   color: string;
@@ -54,9 +54,38 @@ export const Board: React.FC<BoardProps> = ({
   pieceOrientation,
   overlayMap,
 }) => {
-  const { gameState, previewMove, setPreviewMove, currentSliderTurn } = useGameStore();
+  const { gameState, previewMove, setPreviewMove, currentSliderTurn, pendingPlacement } = useGameStore();
   const [hoveredCell, setHoveredCell] = useState<{ row: number, col: number } | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
+
+  const cursorOffset = useMemo(
+    () => (selectedPiece ? getPieceCursorOffset(selectedPiece, pieceOrientation) : { row: 0, col: 0 }),
+    [selectedPiece, pieceOrientation]
+  );
+
+  // Optimistic placement: paint the pending piece immediately with the player's
+  // color, skipping squares already filled on the authoritative board (so an
+  // illegal overlap never hides the real state).
+  const pendingCells = useMemo<Record<string, string>>(() => {
+    if (!pendingPlacement) return {};
+    const positions = calculatePiecePositions(
+      pendingPlacement.piece_id,
+      pendingPlacement.orientation,
+      pendingPlacement.anchor_row,
+      pendingPlacement.anchor_col
+    );
+    const playerColor =
+      PLAYER_COLORS[pendingPlacement.player.toLowerCase() as keyof typeof PLAYER_COLORS] ||
+      PLAYER_COLORS.empty;
+    const board = gameState?.board;
+    const out: Record<string, string> = {};
+    for (const p of positions) {
+      if (p.row < 0 || p.row >= BOARD_SIZE || p.col < 0 || p.col >= BOARD_SIZE) continue;
+      if (board && board[p.row]?.[p.col]) continue;
+      out[`${p.row}-${p.col}`] = playerColor;
+    }
+    return out;
+  }, [pendingPlacement, gameState?.board]);
 
   // Performance instrumentation - measure render time
   useEffect(() => {
@@ -103,23 +132,16 @@ export const Board: React.FC<BoardProps> = ({
 
     if (previewMove) setPreviewMove(null);
 
-    // Anchor = top-left of piece. Preview uses hoveredCell as anchor, so when user
-    // clicks a preview cell, pass hoveredCell (the anchor), not the clicked cell.
-    if (selectedPiece && hoveredCell) {
-      const previewPositions = calculatePiecePositions(
-        selectedPiece,
-        pieceOrientation,
-        hoveredCell.row,
-        hoveredCell.col
-      );
-      const isOnPreview = previewPositions.some((p) => p.row === row && p.col === col);
-      if (isOnPreview) {
-        onCellClick(hoveredCell.row, hoveredCell.col);
-        return;
-      }
+    // With a selected piece, cursor sits on cursorOffset within the piece, so
+    // translate the cursor cell back to the piece's bounding-box anchor.
+    if (selectedPiece) {
+      const anchorRow = row - cursorOffset.row;
+      const anchorCol = col - cursorOffset.col;
+      onCellClick(anchorRow, anchorCol);
+      return;
     }
     onCellClick(row, col);
-  }, [onCellClick, selectedPiece, pieceOrientation, hoveredCell, previewMove, setPreviewMove]);
+  }, [onCellClick, selectedPiece, cursorOffset, previewMove, setPreviewMove]);
 
   // Memoize cell color calculation to avoid recomputation
   const cellColors = useMemo(() => {
@@ -176,7 +198,15 @@ export const Board: React.FC<BoardProps> = ({
     return piecePreview.some(pos => pos.row === row && pos.col === col);
   };
 
+  const getPendingColor = (row: number, col: number): string | undefined => {
+    return pendingCells[`${row}-${col}`];
+  };
+
   const getCellFillColor = (row: number, col: number) => {
+    // Optimistic pending placement renders as a solid placed piece.
+    const pending = getPendingColor(row, col);
+    if (pending) return pending;
+
     // Preview cells (ghost piece) should be transparent (hollow)
     if (isPreviewCell(row, col)) {
       return 'transparent';
@@ -197,6 +227,8 @@ export const Board: React.FC<BoardProps> = ({
   };
 
   const getCellStroke = (row: number, col: number) => {
+    // Pending (optimistic) cells render as solid placed pieces — no stroke.
+    if (getPendingColor(row, col)) return 'none';
     // Ghost piece cells get preview color stroke only (hollow rectangle)
     if (isPreviewCell(row, col)) {
       return PLAYER_COLORS.preview;
@@ -205,6 +237,7 @@ export const Board: React.FC<BoardProps> = ({
   };
 
   const getCellStrokeWidth = (row: number, col: number) => {
+    if (getPendingColor(row, col)) return 0;
     // Ghost piece cells get 2px border
     if (isPreviewCell(row, col)) {
       return 2;
@@ -213,6 +246,7 @@ export const Board: React.FC<BoardProps> = ({
   };
 
   const hasPlacedPiece = (row: number, col: number) => {
+    if (getPendingColor(row, col)) return true;
     // Check if this cell has a placed piece (not empty, not preview, not hover)
     const cellColor = getCellColor(row, col);
     return cellColor !== PLAYER_COLORS.empty && !isPreviewCell(row, col);
@@ -240,8 +274,12 @@ export const Board: React.FC<BoardProps> = ({
     }
     if (!selectedPiece || !hoveredCell) return [];
 
-    // Calculate piece positions based on shape and orientation
-    const positions = calculatePiecePositions(selectedPiece, pieceOrientation, hoveredCell.row, hoveredCell.col);
+    // Calculate piece positions based on shape and orientation.
+    // cursorOffset is the cell within the piece that sits under the cursor,
+    // so the bounding-box anchor is hoveredCell minus that offset.
+    const anchorRow = hoveredCell.row - cursorOffset.row;
+    const anchorCol = hoveredCell.col - cursorOffset.col;
+    const positions = calculatePiecePositions(selectedPiece, pieceOrientation, anchorRow, anchorCol);
 
     // Filter out positions that are outside the board
     const validPositions = positions.filter(

--- a/frontend/src/components/PieceTray.tsx
+++ b/frontend/src/components/PieceTray.tsx
@@ -142,7 +142,11 @@ export const PieceTray: React.FC<PieceTrayProps> = ({
             // Check if piece is already used for the display player
             const pieceUsedList = gameState?.pieces_used?.[displayPlayer || ''] || [];
             const isPieceUsed = pieceUsedList.includes(pieceId);
-            const isViewingOther = viewingPlayer !== null && viewingPlayer !== undefined && viewingPlayer !== (gameState?.current_player);
+            // Block selection only when the tray shows a non-human player's pieces.
+            // If the human hasn't been identified (no players config), allow selection
+            // so offline / default modes keep working.
+            const humanPlayerColor = gameState?.players?.find((p: any) => p.agent_type === 'human')?.player ?? null;
+            const isViewingOther = humanPlayerColor !== null && displayPlayer !== humanPlayerColor;
 
             return (
               <div

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -24,6 +24,7 @@ export const Play: React.FC = () => {
     error,
     isPaused,
     togglePause,
+    setPendingPlacement,
   } = useGameStore();
 
   const [isMakingMove, setIsMakingMove] = useState(false);
@@ -105,13 +106,19 @@ export const Play: React.FC = () => {
       return;
     }
 
-    // Reset any previous error state
-    setError(null);
-
     // Check if it's a human player's turn (not an agent)
     const currentPlayer = gameState?.current_player;
     const playerConfig = gameState?.players?.find((p: any) => p.player === currentPlayer);
     const isHumanPlayer = playerConfig?.agent_type === 'human';
+
+    // Silently ignore clicks outside the human's turn — users may pre-select
+    // pieces during opponent turns and the click lands on the board.
+    if (gameState?.players && !isHumanPlayer) {
+      return;
+    }
+
+    // Reset any previous error state
+    setError(null);
 
     // Check if the selected piece is already used
     const piecesUsed = gameState?.pieces_used || {};
@@ -120,12 +127,6 @@ export const Play: React.FC = () => {
 
     if (isPieceAlreadyUsed) {
       setError(`Piece ${selectedPiece} has already been used by ${currentPlayer}`);
-      return;
-    }
-
-    // If we don't have player info, assume it's a human player for now
-    if (gameState?.players && !isHumanPlayer) {
-      setError('Only human players can make manual moves');
       return;
     }
 
@@ -143,15 +144,28 @@ export const Play: React.FC = () => {
 
 
     try {
-      const currentPlayer = gameState?.current_player || '';
+      const playerForMove = (currentPlayer || '').toUpperCase();
 
       const moveRequest = {
-        player: currentPlayer.toUpperCase(),
+        player: playerForMove,
         piece_id: selectedPiece,
         orientation: pieceOrientation,
         anchor_row: row,
         anchor_col: col
       };
+
+      // Optimistic UI: paint the piece on the board immediately so the user
+      // gets instant feedback while the Pyodide worker processes the move.
+      setPendingPlacement({
+        player: playerForMove,
+        piece_id: selectedPiece,
+        orientation: pieceOrientation,
+        anchor_row: row,
+        anchor_col: col,
+      });
+      // Clear the ghost preview right away — the optimistic piece replaces it.
+      selectPiece(null);
+      setPieceOrientation(0);
 
       // Send the move to the backend
       console.log('[UI] Sending move', {
@@ -166,23 +180,24 @@ export const Play: React.FC = () => {
 
       if (response && response.success) {
         console.log('✅ Move successful');
-        // Clear the selected piece only after successful move
-        selectPiece(null);
-        setPieceOrientation(0);
       } else {
-        // Move failed - display the specific error message from the backend
+        // Move failed — optimistic overlay is cleared in the store's
+        // move_response handler; restore the piece so the user can retry.
         console.log('❌ Move failed, response:', response);
         const errorMessage = response?.message || 'Move failed';
         console.log('📝 Error message from backend:', errorMessage);
         setError(errorMessage);
+        selectPiece(selectedPiece);
+        setPieceOrientation(pieceOrientation);
       }
     } catch (err) {
       console.error('Move error:', err);
       setError(err instanceof Error ? err.message : String(err));
+      setPendingPlacement(null);
     } finally {
       setIsMakingMove(false);
     }
-  }, [selectedPiece, isMakingMove, gameState, pieceOrientation, makeMove, selectPiece, setPieceOrientation, setError]);
+  }, [selectedPiece, isMakingMove, gameState, pieceOrientation, makeMove, selectPiece, setPieceOrientation, setError, setPendingPlacement]);
 
   const handleCellHover = useCallback(() => {
     // Could add hover effects here

--- a/frontend/src/store/gameStore.ts
+++ b/frontend/src/store/gameStore.ts
@@ -167,6 +167,14 @@ export interface GameHistoryEntry {
   mcts_diagnostics?: MctsDiagnosticsV1;
 }
 
+export interface PendingPlacement {
+  player: string;
+  piece_id: number;
+  orientation: number;
+  anchor_row: number;
+  anchor_col: number;
+}
+
 // Store interface
 interface GameStore {
   gameState: GameState | null;
@@ -175,6 +183,7 @@ interface GameStore {
   selectedPiece: number | null;
   pieceOrientation: number;
   previewMove: MctsTopMove | null;
+  pendingPlacement: PendingPlacement | null;
   pollIntervalId: ReturnType<typeof setInterval> | null;
   isAdvancingTurn: boolean;
   isPaused: boolean;
@@ -192,6 +201,7 @@ interface GameStore {
   selectPiece: (pieceId: number | null) => void;
   setPieceOrientation: (orientation: number) => void;
   setPreviewMove: (move: MctsTopMove | null) => void;
+  setPendingPlacement: (placement: PendingPlacement | null) => void;
   makeMove: (move: MoveRequest) => Promise<MoveResponse>;
   passTurn: () => Promise<MoveResponse>;
   createGame: (config: any) => Promise<string>;
@@ -232,7 +242,7 @@ function setupWorker() {
     } else if (data.type === 'move_response') {
       const resp = data.response;
       useGameStore.getState().setGameState(resp.game_state);
-      useGameStore.setState({ isAdvancingTurn: false });
+      useGameStore.setState({ isAdvancingTurn: false, pendingPlacement: null });
       if (moveResolver) {
         moveResolver(resp);
         moveResolver = null;
@@ -241,6 +251,7 @@ function setupWorker() {
     } else if (data.type === 'error' || data.type === 'init_error') {
       console.error("Worker Error:", data.error);
       useGameStore.getState().setError(data.error);
+      useGameStore.setState({ pendingPlacement: null });
       useGameStore.getState().addLog("Worker Error: " + data.error, "ERROR");
     }
   };
@@ -270,6 +281,7 @@ export const useGameStore = create<GameStore>()(
     selectedPiece: null,
     pieceOrientation: 0,
     previewMove: null,
+    pendingPlacement: null,
     pollIntervalId: null,
     isAdvancingTurn: false,
     isPaused: false,
@@ -307,6 +319,7 @@ export const useGameStore = create<GameStore>()(
         currentSliderTurn: null,
         isAdvancingTurn: false,
         isPaused: false,
+        pendingPlacement: null,
       });
     },
 
@@ -324,6 +337,10 @@ export const useGameStore = create<GameStore>()(
 
     setPreviewMove: (move: MctsTopMove | null) => {
       set({ previewMove: move });
+    },
+
+    setPendingPlacement: (placement: PendingPlacement | null) => {
+      set({ pendingPlacement: placement });
     },
 
     passTurn: async (): Promise<MoveResponse> => {

--- a/frontend/src/utils/pieceUtils.test.ts
+++ b/frontend/src/utils/pieceUtils.test.ts
@@ -4,7 +4,7 @@
  * calculatePiecePositions uses anchor as the position of shape[0][0].
  */
 import { describe, it, expect } from 'vitest';
-import { calculatePiecePositions } from './pieceUtils';
+import { calculatePiecePositions, getPieceCursorOffset, getPieceShape } from './pieceUtils';
 
 describe('calculatePiecePositions (anchor = top-left)', () => {
   it('piece 1 (monomino) at anchor (0,0) places at (0,0)', () => {
@@ -48,5 +48,41 @@ describe('calculatePiecePositions (anchor = top-left)', () => {
     const positions = calculatePiecePositions(6, 0, anchorRow, anchorCol);
     const includesClicked = positions.some((p) => p.row === 1 && p.col === 1);
     expect(includesClicked).toBe(true);
+  });
+});
+
+describe('getPieceCursorOffset', () => {
+  it('always returns a filled cell for every piece and orientation', () => {
+    for (let pieceId = 1; pieceId <= 21; pieceId++) {
+      for (let orientation = 0; orientation < 8; orientation++) {
+        const shape = getPieceShape(pieceId, orientation);
+        const offset = getPieceCursorOffset(pieceId, orientation);
+        expect(shape[offset.row]?.[offset.col]).toBe(1);
+      }
+    }
+  });
+
+  it('returns (0,0) for a monomino', () => {
+    expect(getPieceCursorOffset(1, 0)).toEqual({ row: 0, col: 0 });
+  });
+
+  it('placing preview via cursor keeps the cursor cell covered', () => {
+    // For every piece and orientation, placing the piece so that its anchor is
+    // (cursor - offset) must produce a cell covering the cursor itself.
+    const cursorRow = 7;
+    const cursorCol = 7;
+    for (let pieceId = 1; pieceId <= 21; pieceId++) {
+      for (let orientation = 0; orientation < 8; orientation++) {
+        const offset = getPieceCursorOffset(pieceId, orientation);
+        const positions = calculatePiecePositions(
+          pieceId,
+          orientation,
+          cursorRow - offset.row,
+          cursorCol - offset.col
+        );
+        const covers = positions.some((p) => p.row === cursorRow && p.col === cursorCol);
+        expect(covers).toBe(true);
+      }
+    }
   });
 });

--- a/frontend/src/utils/pieceUtils.ts
+++ b/frontend/src/utils/pieceUtils.ts
@@ -59,14 +59,14 @@ export const getPieceShape = (pieceId: number, orientation: number): number[][] 
 };
 
 export const calculatePiecePositions = (
-  pieceId: number, 
-  orientation: number, 
-  anchorRow: number, 
+  pieceId: number,
+  orientation: number,
+  anchorRow: number,
   anchorCol: number
 ): Position[] => {
   const shape = getPieceShape(pieceId, orientation);
   const positions: Position[] = [];
-  
+
   for (let row = 0; row < shape.length; row++) {
     for (let col = 0; col < shape[row].length; col++) {
       if (shape[row][col] === 1) {
@@ -77,6 +77,50 @@ export const calculatePiecePositions = (
       }
     }
   }
-  
+
   return positions;
+};
+
+/**
+ * Offset (relative to anchor = bounding-box top-left) of the piece cell that
+ * should sit under the cursor. Picks the filled square nearest the shape's
+ * centroid; ties resolve to top-most, then left-most. Guarantees the cursor
+ * always overlaps an actual piece square.
+ */
+export const getPieceCursorOffset = (
+  pieceId: number,
+  orientation: number
+): Position => {
+  const shape = getPieceShape(pieceId, orientation);
+  const filled: Position[] = [];
+  for (let row = 0; row < shape.length; row++) {
+    for (let col = 0; col < shape[row].length; col++) {
+      if (shape[row][col] === 1) filled.push({ row, col });
+    }
+  }
+  if (filled.length === 0) return { row: 0, col: 0 };
+
+  let sumR = 0;
+  let sumC = 0;
+  for (const p of filled) {
+    sumR += p.row;
+    sumC += p.col;
+  }
+  const cR = sumR / filled.length;
+  const cC = sumC / filled.length;
+
+  let best = filled[0];
+  let bestD = Infinity;
+  for (const p of filled) {
+    const dr = p.row - cR;
+    const dc = p.col - cC;
+    const d = dr * dr + dc * dc;
+    if (d < bestD - 1e-9 ||
+        (Math.abs(d - bestD) < 1e-9 && (p.row < best.row ||
+          (p.row === best.row && p.col < best.col)))) {
+      best = p;
+      bestD = d;
+    }
+  }
+  return best;
 };


### PR DESCRIPTION
- Cursor now sits on a filled square near the piece's centroid for every
  shape/orientation, replacing the bounding-box anchor that left the
  cursor floating away from the ghost preview.
- Click now paints the piece on the board immediately via an
  optimistic pendingPlacement overlay; the Pyodide worker response
  reconciles (and clears) it afterwards, so placement feels instant.
- The piece tray unlocks piece selection whenever the viewed tray
  belongs to the human player, so users can pre-select / rotate / flip
  during opponent turns. Board clicks outside the human's turn are
  silently ignored instead of raising an error banner.

https://claude.ai/code/session_01BPXFREj19eAmJwfk6opzdt