### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ out/
 *.db
 
 # Project Artifacts
+.worktrees/
 checkpoints/
 logs/
 runs/


### PR DESCRIPTION
## Summary
- add `.worktrees/` to `.gitignore` so local worktree directories do not appear in repository status or accidental diffs

## Test plan
- Not run (gitignore-only change)

Made with [Cursor](https://cursor.com)