### PR TITLE
Add Champion Gauntlet v1 reference run specification and configs

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -55,6 +55,7 @@
 - Self-improvement loop with metric tracking — `scripts/self_improve.py`
 - Champion self-improvement loop: persistent champion vs 5-tier randomized challenger pool (14 agents), snapshot-driven evaluator recalibration with validation mini-tournament before weight promotion, versioned champion registry, TrueSkill tracking, and Markdown progress report — `scripts/champion_loop.py`, `data/champion_registry.json`, `data/champion_progress.md`
 - Champion arena: champion vs randomized pool with persistent TrueSkill, snapshot data collection, auto-promotion, and per-run markdown reports — `scripts/champion_arena.py`, `data/champion_state.json`, `data/champion_reports/`
+- Champion gauntlet reference run (v1): documented 40-game specification for champion vs Tier 3/4/5 challengers with snapshot collection and expected-outcome analysis — `arena_runs/champion_gauntlet_v1/`, `scripts/arena_config_champion_gauntlet.json`, `config/champion_arena_params.json`
 - Persistent cross-session TrueSkill seeding via `load_ratings()` — `analytics/tournament/trueskill_rating.py`
 - Throughput calibration — `scripts/calibrate_throughput.py`, `data/throughput_calibration.json`
 

--- a/arena_runs/champion_gauntlet_v1/run_config.json
+++ b/arena_runs/champion_gauntlet_v1/run_config.json
@@ -1,0 +1,184 @@
+{
+  "run_id": "champion_gauntlet_v1",
+  "created_at": "2026-05-03T00:00:00",
+  "notes": "Champion Gauntlet v1 — reference run specification. Champion (v1, Layers 3-7+9, all features, 500 ms) vs three challengers spanning Tier 3 (L4+5 enhanced, 100 ms), Tier 4 (L9 partial, 200 ms), and Tier 5 (near-peer, 500 ms, no opponent model). Snapshots at plies 8-64 for evaluator refinement. Run with: python scripts/champion_loop.py --iterations 1 --games-per-iter 40 --seed 20260503",
+  "agents": [
+    {
+      "name": "champion",
+      "type": "mcts",
+      "thinking_time_ms": 500,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "exploration_constant": 1.414,
+        "use_transposition_table": true,
+        "progressive_widening_enabled": true,
+        "pw_c": 2.0,
+        "pw_alpha": 0.5,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        },
+        "state_eval_phase_weights": {
+          "early": {
+            "squares_placed": -0.17599664484103847,
+            "remaining_piece_area": 0.17599664484103822,
+            "accessible_corners": 0.3,
+            "reachable_empty_squares": 0.0,
+            "largest_remaining_piece_size": 0.0,
+            "opponent_avg_mobility": -0.05287834609528694,
+            "center_proximity": 0.0,
+            "territory_enclosure_area": 0.0
+          },
+          "mid": {
+            "squares_placed": -0.00387502185581506,
+            "remaining_piece_area": 0.0038750218558150614,
+            "accessible_corners": 0.3,
+            "reachable_empty_squares": 0.22774497158891033,
+            "largest_remaining_piece_size": -0.238473591231953,
+            "opponent_avg_mobility": -0.20277351241243552,
+            "center_proximity": 0.0,
+            "territory_enclosure_area": 0.0
+          },
+          "late": {
+            "squares_placed": 0.3,
+            "remaining_piece_area": -0.3,
+            "accessible_corners": 0.17573409689186584,
+            "reachable_empty_squares": 0.13361753070802862,
+            "largest_remaining_piece_size": -0.08518919739412929,
+            "opponent_avg_mobility": -0.06278383996091268,
+            "center_proximity": 0.0,
+            "territory_enclosure_area": 0.0
+          }
+        },
+        "opponent_modeling_enabled": true,
+        "alliance_detection_enabled": true,
+        "alliance_threshold": 2.0,
+        "kingmaker_detection_enabled": true,
+        "kingmaker_score_gap": 15,
+        "adaptive_rollout_depth_enabled": true,
+        "adaptive_rollout_depth_base": 5,
+        "adaptive_rollout_depth_avg_bf": 80.0,
+        "adaptive_exploration_enabled": true,
+        "adaptive_exploration_base": 1.414,
+        "adaptive_exploration_avg_bf": 80.0,
+        "sufficiency_threshold_enabled": true,
+        "loss_avoidance_enabled": true,
+        "loss_avoidance_threshold": -50.0
+      }
+    },
+    {
+      "name": "pool_l45_100ms",
+      "type": "mcts",
+      "thinking_time_ms": 100,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        }
+      }
+    },
+    {
+      "name": "pool_l9_partial_200ms",
+      "type": "mcts",
+      "thinking_time_ms": 200,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        },
+        "adaptive_exploration_enabled": true,
+        "adaptive_exploration_base": 1.414,
+        "adaptive_exploration_avg_bf": 80.0,
+        "adaptive_rollout_depth_enabled": true,
+        "adaptive_rollout_depth_base": 5,
+        "sufficiency_threshold_enabled": true,
+        "loss_avoidance_enabled": true
+      }
+    },
+    {
+      "name": "pool_peer_500ms",
+      "type": "mcts",
+      "thinking_time_ms": 500,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "exploration_constant": 1.414,
+        "use_transposition_table": true,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        },
+        "progressive_widening_enabled": true,
+        "pw_c": 2.0,
+        "pw_alpha": 0.5,
+        "adaptive_exploration_enabled": true,
+        "adaptive_exploration_base": 1.414,
+        "adaptive_exploration_avg_bf": 80.0,
+        "adaptive_rollout_depth_enabled": true,
+        "adaptive_rollout_depth_base": 5,
+        "adaptive_rollout_depth_avg_bf": 80.0,
+        "sufficiency_threshold_enabled": true,
+        "loss_avoidance_enabled": true
+      }
+    }
+  ],
+  "num_games": 40,
+  "seed": 20260503,
+  "seat_policy": "round_robin",
+  "output_root": "arena_runs",
+  "max_turns": 2500,
+  "snapshots": {
+    "enabled": true,
+    "strategy": "fixed_ply",
+    "checkpoints": [8, 16, 24, 32, 40, 48, 56, 64]
+  }
+}

--- a/arena_runs/champion_gauntlet_v1/summary.md
+++ b/arena_runs/champion_gauntlet_v1/summary.md
@@ -1,0 +1,121 @@
+# Champion Gauntlet v1
+
+## Overview
+
+- **Run type**: Champion self-improvement gauntlet (reference specification)
+- **Champion version**: v1
+- **Games**: 40 (round-robin seat rotation)
+- **Seed**: `20260503`
+- **Snapshots**: fixed-ply at plies 8, 16, 24, 32, 40, 48, 56, 64
+- **Purpose**: Establish champion v1 baseline TrueSkill and generate initial snapshot data for evaluator refinement
+
+To reproduce:
+```
+python scripts/champion_loop.py --iterations 1 --games-per-iter 40 --seed 20260503
+```
+
+---
+
+## Champion Configuration (v1)
+
+The champion encodes all beneficial MCTS layers identified through the Layer 1-9 experiments:
+
+| Layer | Feature | Setting |
+|-------|---------|---------|
+| 1/2 | UCB1 exploration | C = 1.414, transposition table |
+| 3 | Progressive widening | c = 2.0, α = 0.5 |
+| 4 | Rollout policy | random, cutoff depth = 5, minimax α = 0.25 |
+| 5 | RAVE | k = 1000 (β ≈ 0.18 at N=100) |
+| 6 | Evaluator weights | Calibrated from 13K+ self-play states, phase-dependent (early/mid/late) |
+| 7 | Opponent modeling | Alliance detection (threshold 2×avg), king-maker awareness (gap 15), adaptive profiles |
+| 9 | Meta-optimization | Adaptive C (BF-normalized), adaptive rollout depth, sufficiency threshold, loss avoidance |
+
+**Thinking time**: 500 ms → ~250 iterations per move at 0.5 iter/ms
+
+---
+
+## Challenger Pool (this run)
+
+Three challengers were selected to span the difficulty spectrum:
+
+| Agent | Tier | Budget | Differentiating features |
+|-------|------|--------|--------------------------|
+| `pool_l45_100ms` | 3 — L4+5 enhanced | 100 ms (50 iter) | Rollout cutoff, minimax, RAVE — no opponent model, no L9 |
+| `pool_l9_partial_200ms` | 4 — L9 partial | 200 ms (100 iter) | Full L9 adaptive meta-opts — no opponent model, half budget |
+| `pool_peer_500ms` | 5 — Near-peer | 500 ms (250 iter) | Same budget as champion, same L3/4/5/9 — **no opponent model** |
+
+**Key test**: Does opponent modeling (Layer 7) provide a net win-rate advantage vs the near-peer at equal budget?  
+**Secondary test**: Does the champion's advantage over pool_l45_100ms reflect the expected ~L7+L9 compound gain?
+
+---
+
+## Expected Outcomes (based on Layer 1-9 experiment history)
+
+### Win rate estimates
+
+| Matchup (champion vs) | Expected champion WR | Basis |
+|----------------------|----------------------|-------|
+| `pool_l45_100ms` | 55–70% | 5× more iterations + L7+L9 |
+| `pool_l9_partial_200ms` | 50–60% | 2.5× more iterations + L7 |
+| `pool_peer_500ms` | 45–55% | Equal iterations; L7 advantage only |
+
+**Overall expected champion WR**: ~0.40–0.55 (4-player: 25% is neutral)
+
+### TrueSkill trajectory
+
+Starting from μ = 25, σ = 8.33 for all agents:
+
+- After 40 games each player appears in ~10 games (round-robin).  
+- σ should drop to ~6–7 range after 40 games; convergence (σ < 6.5) likely requires 100+ games.
+- Champion's μ expected to settle above 26–28 once σ converges.
+
+### Snapshot yield
+
+- 40 games × 8 checkpoints × 4 players = **1280 snapshot rows**
+- Phase distribution: ~30% early, ~40% mid, ~30% late (empirical from existing runs)
+- 1280 rows exceeds the 1000-row threshold in `champion_loop.py` for triggering evaluator recalibration
+
+---
+
+## Evaluator Refinement Pipeline
+
+After this run completes, `champion_loop.py` will:
+
+1. Accumulate snapshot rows into `data/champion_registry.json` → `snapshot_csv_paths`
+2. Run inline regression (`analyze_layer6_features.py` / `train_eval_model.py`) on all accumulated rows
+3. Validate new weights in a mini-tournament (10 games) before promoting
+4. If promoted: bump champion to v2, update `state_eval_weights` in the registry
+
+---
+
+## Relationship to Previous Arena Runs
+
+| Prior run | Date | Purpose | Key finding |
+|-----------|------|---------|-------------|
+| `20260325_021148_78fbdc50` | 2026-03-25 | L6 phase vs single weights | Phase weights hurt at this budget |
+| `20260325_033805_9b3944b6` | 2026-03-25 | L4 combined (cutoff + minimax) | cutoff=5 + minimax α=0.25 best |
+| `20260325_201856_32cf0875` | 2026-03-25 | L3 PW + PH combined | PW dominates; PW+PH best overall |
+
+The champion v1 incorporates all three winning configurations (PW from L3, cutoff+minimax from L4, RAVE from L5) plus opponent modeling (L7) and adaptive meta-optimization (L9) on top.
+
+---
+
+## How to Run
+
+```bash
+# Single iteration, 40 games (this specification)
+python scripts/champion_loop.py --iterations 1 --games-per-iter 40
+
+# Extended multi-iteration training run (produces evaluator recalibration after iteration 1)
+python scripts/champion_loop.py --iterations 10 --games-per-iter 40
+
+# View progress after runs complete
+python scripts/champion_loop.py --show
+
+# Force evaluator recalibration after any run
+python scripts/champion_loop.py --retrain
+```
+
+Results land in `arena_runs/{timestamp}_{hash}/` with full `summary.json`, `summary.md`,
+`games.jsonl`, and `snapshots.csv/parquet`. TrueSkill and iteration history are persisted
+to `data/champion_registry.json`; the Markdown progress report is at `data/champion_progress.md`.

--- a/config/champion_arena_params.json
+++ b/config/champion_arena_params.json
@@ -1,0 +1,73 @@
+{
+  "description": "Champion v1 arena params — full feature set (Layers 3-7 + 9) at 500 ms thinking time. Matches CHAMPION_BASE_PARAMS in champion_loop.py with calibrated phase weights from layer6_calibrated_weights.json injected at runtime. Used by scripts/arena_config_champion_gauntlet.json and as reference for champion_loop.py.",
+  "champion_version": "v1",
+  "thinking_time_ms": 500,
+  "deterministic_time_budget": true,
+  "iterations_per_ms": 0.5,
+  "exploration_constant": 1.414,
+  "use_transposition_table": true,
+  "rollout_policy": "random",
+  "rollout_cutoff_depth": 5,
+  "minimax_backup_alpha": 0.25,
+  "rave_enabled": true,
+  "rave_k": 1000,
+  "progressive_widening_enabled": true,
+  "pw_c": 2.0,
+  "pw_alpha": 0.5,
+  "state_eval_weights": {
+    "squares_placed": 0.0295,
+    "remaining_piece_area": -0.0295,
+    "accessible_corners": 0.243,
+    "reachable_empty_squares": 0.081,
+    "largest_remaining_piece_size": -0.231,
+    "opponent_avg_mobility": -0.3,
+    "center_proximity": 0.0,
+    "territory_enclosure_area": 0.0
+  },
+  "opponent_modeling_enabled": true,
+  "alliance_detection_enabled": true,
+  "alliance_threshold": 2.0,
+  "kingmaker_detection_enabled": true,
+  "kingmaker_score_gap": 15,
+  "adaptive_rollout_depth_enabled": true,
+  "adaptive_rollout_depth_base": 5,
+  "adaptive_rollout_depth_avg_bf": 80.0,
+  "adaptive_exploration_enabled": true,
+  "adaptive_exploration_base": 1.414,
+  "adaptive_exploration_avg_bf": 80.0,
+  "sufficiency_threshold_enabled": true,
+  "loss_avoidance_enabled": true,
+  "loss_avoidance_threshold": -50.0,
+  "state_eval_phase_weights": {
+    "early": {
+      "squares_placed": -0.17599664484103847,
+      "remaining_piece_area": 0.17599664484103822,
+      "accessible_corners": 0.3,
+      "reachable_empty_squares": 0.0,
+      "largest_remaining_piece_size": 0.0,
+      "opponent_avg_mobility": -0.05287834609528694,
+      "center_proximity": 0.0,
+      "territory_enclosure_area": 0.0
+    },
+    "mid": {
+      "squares_placed": -0.00387502185581506,
+      "remaining_piece_area": 0.0038750218558150614,
+      "accessible_corners": 0.3,
+      "reachable_empty_squares": 0.22774497158891033,
+      "largest_remaining_piece_size": -0.238473591231953,
+      "opponent_avg_mobility": -0.20277351241243552,
+      "center_proximity": 0.0,
+      "territory_enclosure_area": 0.0
+    },
+    "late": {
+      "squares_placed": 0.3,
+      "remaining_piece_area": -0.3,
+      "accessible_corners": 0.17573409689186584,
+      "reachable_empty_squares": 0.13361753070802862,
+      "largest_remaining_piece_size": -0.08518919739412929,
+      "opponent_avg_mobility": -0.06278383996091268,
+      "center_proximity": 0.0,
+      "territory_enclosure_area": 0.0
+    }
+  }
+}

--- a/scripts/arena_config_champion_gauntlet.json
+++ b/scripts/arena_config_champion_gauntlet.json
@@ -1,0 +1,182 @@
+{
+  "notes": "Champion Gauntlet v1 — reproducible reference run. Champion (v1, all layers enabled, 500 ms) vs one fixed challenger from each pool tier: Tier 3 (L4+5, 100 ms), Tier 4 (L9 partial, 200 ms), Tier 5 (near-peer, 500 ms, no opponent model). Snapshots at plies 8-64 for evaluator refinement. Run with: python scripts/arena.py --config scripts/arena_config_champion_gauntlet.json",
+  "agents": [
+    {
+      "name": "champion",
+      "type": "mcts",
+      "thinking_time_ms": 500,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "exploration_constant": 1.414,
+        "use_transposition_table": true,
+        "progressive_widening_enabled": true,
+        "pw_c": 2.0,
+        "pw_alpha": 0.5,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        },
+        "state_eval_phase_weights": {
+          "early": {
+            "squares_placed": -0.17599664484103847,
+            "remaining_piece_area": 0.17599664484103822,
+            "accessible_corners": 0.3,
+            "reachable_empty_squares": 0.0,
+            "largest_remaining_piece_size": 0.0,
+            "opponent_avg_mobility": -0.05287834609528694,
+            "center_proximity": 0.0,
+            "territory_enclosure_area": 0.0
+          },
+          "mid": {
+            "squares_placed": -0.00387502185581506,
+            "remaining_piece_area": 0.0038750218558150614,
+            "accessible_corners": 0.3,
+            "reachable_empty_squares": 0.22774497158891033,
+            "largest_remaining_piece_size": -0.238473591231953,
+            "opponent_avg_mobility": -0.20277351241243552,
+            "center_proximity": 0.0,
+            "territory_enclosure_area": 0.0
+          },
+          "late": {
+            "squares_placed": 0.3,
+            "remaining_piece_area": -0.3,
+            "accessible_corners": 0.17573409689186584,
+            "reachable_empty_squares": 0.13361753070802862,
+            "largest_remaining_piece_size": -0.08518919739412929,
+            "opponent_avg_mobility": -0.06278383996091268,
+            "center_proximity": 0.0,
+            "territory_enclosure_area": 0.0
+          }
+        },
+        "opponent_modeling_enabled": true,
+        "alliance_detection_enabled": true,
+        "alliance_threshold": 2.0,
+        "kingmaker_detection_enabled": true,
+        "kingmaker_score_gap": 15,
+        "adaptive_rollout_depth_enabled": true,
+        "adaptive_rollout_depth_base": 5,
+        "adaptive_rollout_depth_avg_bf": 80.0,
+        "adaptive_exploration_enabled": true,
+        "adaptive_exploration_base": 1.414,
+        "adaptive_exploration_avg_bf": 80.0,
+        "sufficiency_threshold_enabled": true,
+        "loss_avoidance_enabled": true,
+        "loss_avoidance_threshold": -50.0
+      }
+    },
+    {
+      "name": "pool_l45_100ms",
+      "type": "mcts",
+      "thinking_time_ms": 100,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        }
+      }
+    },
+    {
+      "name": "pool_l9_partial_200ms",
+      "type": "mcts",
+      "thinking_time_ms": 200,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        },
+        "adaptive_exploration_enabled": true,
+        "adaptive_exploration_base": 1.414,
+        "adaptive_exploration_avg_bf": 80.0,
+        "adaptive_rollout_depth_enabled": true,
+        "adaptive_rollout_depth_base": 5,
+        "sufficiency_threshold_enabled": true,
+        "loss_avoidance_enabled": true
+      }
+    },
+    {
+      "name": "pool_peer_500ms",
+      "type": "mcts",
+      "thinking_time_ms": 500,
+      "params": {
+        "deterministic_time_budget": true,
+        "iterations_per_ms": 0.5,
+        "exploration_constant": 1.414,
+        "use_transposition_table": true,
+        "rollout_policy": "random",
+        "rollout_cutoff_depth": 5,
+        "minimax_backup_alpha": 0.25,
+        "rave_enabled": true,
+        "rave_k": 1000,
+        "state_eval_weights": {
+          "squares_placed": 0.0295,
+          "remaining_piece_area": -0.0295,
+          "accessible_corners": 0.243,
+          "reachable_empty_squares": 0.081,
+          "largest_remaining_piece_size": -0.231,
+          "opponent_avg_mobility": -0.3,
+          "center_proximity": 0.0,
+          "territory_enclosure_area": 0.0
+        },
+        "progressive_widening_enabled": true,
+        "pw_c": 2.0,
+        "pw_alpha": 0.5,
+        "adaptive_exploration_enabled": true,
+        "adaptive_exploration_base": 1.414,
+        "adaptive_exploration_avg_bf": 80.0,
+        "adaptive_rollout_depth_enabled": true,
+        "adaptive_rollout_depth_base": 5,
+        "adaptive_rollout_depth_avg_bf": 80.0,
+        "sufficiency_threshold_enabled": true,
+        "loss_avoidance_enabled": true
+      }
+    }
+  ],
+  "num_games": 40,
+  "seed": 20260503,
+  "seat_policy": "round_robin",
+  "output_root": "arena_runs",
+  "max_turns": 2500,
+  "snapshots": {
+    "enabled": true,
+    "strategy": "fixed_ply",
+    "checkpoints": [8, 16, 24, 32, 40, 48, 56, 64]
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces the Champion Gauntlet v1 reference run specification—a reproducible baseline evaluation of the champion MCTS agent against a tiered challenger pool. It includes run configuration, arena setup, and comprehensive documentation for establishing the champion v1 baseline and driving evaluator refinement through snapshot-based training.

## Key Changes

- **`arena_runs/champion_gauntlet_v1/run_config.json`**: Complete run specification for the champion loop, defining the champion agent (v1, all layers 3-7+9 enabled, 500ms) and three challengers spanning difficulty tiers (100ms, 200ms, 500ms). Includes snapshot checkpoints at plies 8-64 for evaluator refinement.

- **`scripts/arena_config_champion_gauntlet.json`**: Standalone arena configuration for reproducible reference runs, matching the champion loop specification but executable via `scripts/arena.py` for isolated testing.

- **`arena_runs/champion_gauntlet_v1/summary.md`**: Detailed documentation covering:
  - Champion v1 configuration table (all 7 MCTS layers + meta-optimization)
  - Challenger pool rationale and feature differentiation
  - Expected win-rate estimates and TrueSkill trajectory
  - Snapshot yield analysis (1280 rows, exceeding evaluator recalibration threshold)
  - Integration with the evaluator refinement pipeline
  - Relationship to prior Layer 1-9 experiment runs
  - Reproduction and extended training instructions

- **`config/champion_arena_params.json`**: Canonical champion v1 parameter reference file documenting all 40+ MCTS hyperparameters, phase-dependent evaluator weights, and opponent modeling settings. Serves as the source of truth for champion configuration across `champion_loop.py` and arena runs.

- **`FEATURES.md`**: Updated feature list to reflect the new champion self-improvement loop infrastructure.

## Notable Implementation Details

- **Tiered challenger design**: Three agents test specific capability gaps—pool_l45_100ms (no opponent model, 5× fewer iterations), pool_l9_partial_200ms (no opponent model, 2.5× fewer iterations), pool_peer_500ms (equal budget, no opponent model). This isolates the win-rate contribution of Layer 7 (opponent modeling) and Layer 9 (meta-optimization).

- **Snapshot strategy**: Fixed-ply checkpoints (8, 16, 24, 32, 40, 48, 56, 64) across 40 games × 4 players = 1280 snapshot rows, exceeding the 1000-row threshold in `champion_loop.py` to trigger automatic evaluator recalibration.

- **Phase-dependent weights**: Champion v1 includes calibrated early/mid/late phase weights from prior layer6 experiments, enabling adaptive evaluation across game stages.

- **Reproducibility**: Seed `20260503`, round-robin seat rotation, and deterministic time budgets ensure bit-identical replay across runs.

https://claude.ai/code/session_01HpzA8FhfuZEL3gpNQEKDam