### PR TITLE
Standardize agent interface + registry-backed champion contract (Phase 3)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -41,6 +41,8 @@
 - Full MCTS agent (Layers 1-9) — `mcts/mcts_agent.py`
 - Agent registry for dynamic construction — `agents/registry.py`
 - Gameplay protocol for human play — `agents/gameplay_protocol.py`, `agents/gameplay_human.py`
+- Canonical agent interface (Phase 3): single `BlokusAgent` Protocol plus `AgentDecisionContext`/`AgentDecision` and a `decide()` front door that unifies the three historical calling conventions (`select_action`, `choose_move`, legacy RL `act`) behind thin adapters — `agents/interface.py`, `docs/02-architecture/AGENT_INTERFACE.md`
+- Registry-backed champion contract (Phase 3): `load_champion()` resolves the validated champion from `data/champion_registry.json` (config path, validation date, gauntlet run path, win rate, TrueSkill, total games) and builds it through the canonical interface, failing clearly with `NoValidatedChampionError` rather than serving an unvalidated champion — `agents/champion.py`
 
 ## Arena & Tournament System
 

--- a/agents/champion.py
+++ b/agents/champion.py
@@ -1,0 +1,206 @@
+"""Registry-backed champion contract.
+
+The backend and the future web demo should be able to ask for *"the champion"*
+by name and receive the **validated** champion — never an ambiguous or stale
+config, and never a silent fall-back to an unvalidated candidate.
+
+This module is the single resolution point. It:
+
+1. Loads champion metadata from ``data/champion_registry.json``.
+2. Resolves the champion's config path.
+3. Builds the champion agent through the canonical agent layer
+   (:mod:`agents.interface`), reusing the arena's vetted ``build_agent`` so the
+   served champion is byte-for-byte the agent the gauntlet validated.
+4. Surfaces validation metadata (validation date, gauntlet run path, win rate,
+   TrueSkill, total games) alongside the agent.
+5. Fails *clearly* — :class:`NoValidatedChampionError` — when no validated
+   champion exists, instead of returning a half-configured agent.
+
+A registry version counts as a *validated champion* only when it was written by
+the gauntlet promotion path (:func:`analytics.tournament.gauntlet.build_registry_entry`),
+i.e. it carries ``gate_pass == True``, a resolvable ``config_path``, and real
+(non-null) ``avg_win_rate``/``avg_trueskill_mu`` metrics. The seed ``v1`` entry
+that ships with null metrics is therefore *not* loadable — by design.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY_PATH = _REPO_ROOT / "data" / "champion_registry.json"
+
+
+class NoValidatedChampionError(RuntimeError):
+    """Raised when the registry contains no validated champion to serve."""
+
+
+@dataclass(frozen=True)
+class ChampionMetadata:
+    """Validation metadata for a registry champion version."""
+
+    version: str
+    champion_name: str
+    config_path: str
+    params: Dict[str, Any]
+    thinking_time_ms: Optional[int]
+    validation_date: Optional[str]
+    gauntlet_run_path: Optional[str]
+    win_rate: Optional[float]
+    trueskill_mu: Optional[float]
+    trueskill_conservative: Optional[float]
+    total_games: Optional[int]
+    promoted_at: Optional[str]
+    promotion_reason: Optional[str]
+
+    def summary(self) -> str:
+        """One-line human summary for logs / API responses."""
+        wr = f"{self.win_rate * 100:.1f}%" if self.win_rate is not None else "n/a"
+        mu = (
+            f"{self.trueskill_mu:.2f}"
+            if self.trueskill_mu is not None
+            else "n/a"
+        )
+        return (
+            f"champion {self.version} '{self.champion_name}' "
+            f"(win_rate={wr}, TrueSkill mu={mu}, "
+            f"games={self.total_games}, validated={self.validation_date})"
+        )
+
+
+@dataclass
+class ChampionHandle:
+    """A loaded champion: its validation metadata plus a ready-to-play agent.
+
+    ``agent`` conforms to the canonical agent layer — it exposes the deploy
+    ``choose_move(board, player, legal_moves, budget_ms) -> (move, stats)``
+    protocol, so it is directly usable by the backend and drivable through
+    :func:`agents.interface.decide`.
+    """
+
+    metadata: ChampionMetadata
+    agent: Any
+
+
+def _load_registry(registry_path: Path) -> Mapping[str, Any]:
+    if not registry_path.exists():
+        raise NoValidatedChampionError(
+            f"Champion registry not found at {registry_path}. "
+            "Run scripts/champion_gauntlet.py --promote to create one."
+        )
+    with registry_path.open("r", encoding="utf-8") as handle:
+        registry = json.load(handle)
+    if not isinstance(registry, Mapping):
+        raise NoValidatedChampionError(
+            f"Champion registry at {registry_path} is not a JSON object."
+        )
+    return registry
+
+
+def _missing_validation_fields(entry: Mapping[str, Any]) -> list[str]:
+    """Return the reasons ``entry`` is not a validated champion (empty == valid)."""
+    reasons: list[str] = []
+    if entry.get("gate_pass") is not True:
+        reasons.append("gate_pass is not True (was not promoted through the gauntlet)")
+    if not entry.get("config_path"):
+        reasons.append("missing config_path")
+    if entry.get("avg_win_rate") is None:
+        reasons.append("avg_win_rate is null")
+    if entry.get("avg_trueskill_mu") is None:
+        reasons.append("avg_trueskill_mu is null")
+    return reasons
+
+
+def load_champion_metadata(
+    registry_path: Optional[Path | str] = None,
+) -> ChampionMetadata:
+    """Resolve and validate the current champion's metadata.
+
+    Raises :class:`NoValidatedChampionError` (with a clear reason) when the
+    registry has no current version, the version is missing, or the entry has not
+    cleared the gauntlet's promotion gates.
+    """
+    registry_path = Path(registry_path) if registry_path else DEFAULT_REGISTRY_PATH
+    registry = _load_registry(registry_path)
+
+    current = registry.get("current_version")
+    if not current:
+        raise NoValidatedChampionError(
+            f"Registry {registry_path} has no current_version set; "
+            "no validated champion exists."
+        )
+
+    versions = registry.get("versions") or {}
+    entry = versions.get(current)
+    if not isinstance(entry, Mapping):
+        raise NoValidatedChampionError(
+            f"Registry {registry_path} current_version '{current}' "
+            "has no matching versions entry."
+        )
+
+    reasons = _missing_validation_fields(entry)
+    if reasons:
+        raise NoValidatedChampionError(
+            f"Registry {registry_path} champion '{current}' is not a validated "
+            f"champion: {'; '.join(reasons)}. "
+            "Promote one with scripts/champion_gauntlet.py --promote; "
+            "refusing to fall back to an unvalidated champion."
+        )
+
+    config_path = str(entry["config_path"])
+    if not Path(config_path).is_absolute():
+        resolved = (_REPO_ROOT / config_path)
+        if resolved.exists():
+            config_path = str(resolved)
+
+    ci = entry.get("win_rate_ci") or {}
+    return ChampionMetadata(
+        version=str(current),
+        champion_name=str(entry.get("champion_name", current)),
+        config_path=config_path,
+        params=dict(entry.get("params") or {}),
+        thinking_time_ms=entry.get("thinking_time_ms"),
+        validation_date=entry.get("validation_date"),
+        gauntlet_run_path=entry.get("gauntlet_run_path"),
+        win_rate=entry.get("avg_win_rate"),
+        trueskill_mu=entry.get("avg_trueskill_mu"),
+        trueskill_conservative=entry.get("trueskill_conservative"),
+        total_games=entry.get("total_games_played"),
+        promoted_at=entry.get("promoted_at"),
+        promotion_reason=entry.get("promotion_reason"),
+    )
+
+
+def build_champion_agent(metadata: ChampionMetadata, seed: Optional[int] = None) -> Any:
+    """Build the champion's gameplay agent from its validated config.
+
+    Reuses the gauntlet's config loader and the arena's ``build_agent`` so the
+    served champion is exactly the agent that was validated. The returned adapter
+    conforms to the canonical agent layer (exposes ``choose_move``).
+    """
+    # Lazy imports: keep this module importable without pulling in the heavy
+    # arena/analytics stack unless a champion is actually being built.
+    from analytics.tournament.arena_runner import AgentConfig, build_agent
+    from analytics.tournament.gauntlet import load_candidate_config
+
+    agent_dict = load_candidate_config(metadata.champion_name, metadata.config_path)
+    config = AgentConfig.from_dict(agent_dict)
+    return build_agent(config, seed=seed if seed is not None else 0)
+
+
+def load_champion(
+    registry_path: Optional[Path | str] = None,
+    seed: Optional[int] = None,
+) -> ChampionHandle:
+    """Load the validated champion (metadata + ready-to-play agent).
+
+    This is the single entry point the backend / web demo should call to request
+    *"champion"*. Raises :class:`NoValidatedChampionError` when no validated
+    champion exists — it never silently serves an unvalidated agent.
+    """
+    metadata = load_champion_metadata(registry_path)
+    agent = build_champion_agent(metadata, seed=seed)
+    return ChampionHandle(metadata=metadata, agent=agent)

--- a/agents/interface.py
+++ b/agents/interface.py
@@ -1,0 +1,216 @@
+"""Canonical Blokus agent interface.
+
+This module formalises *one* move-selection contract for the whole repo so the
+arena, the FastAPI backend, the browser/Pyodide worker, and any future web demo
+all speak the same language, while the older calling conventions survive behind
+thin adapters.
+
+History — why three conventions exist
+-------------------------------------
+The codebase grew three different agent calling conventions:
+
+* ``select_action(board, player, legal_moves) -> Move | None``
+  The *native* method implemented by every real gameplay agent
+  (:class:`agents.random_agent.RandomAgent`,
+  :class:`agents.heuristic_agent.HeuristicAgent`,
+  :class:`mcts.mcts_agent.MCTSAgent`). It is the smallest possible contract:
+  given a position and the legal moves, return one move (or ``None`` when there
+  is nothing to play).
+
+* ``choose_move(board, player, legal_moves, time_budget_ms) -> (Move | None, dict)``
+  The *deploy/web* protocol (:class:`agents.gameplay_protocol.GameplayAgentProtocol`).
+  It adds a per-move time budget and a diagnostics dict (visit counts, search
+  trace, budget tier, ...) needed when serving moves over a websocket.
+
+* ``act(observation, legal_mask, env) -> action_index | None``
+  The *legacy RL-era* protocol (:class:`agents.registry.AgentProtocol`,
+  used by ``league/``). It is index-based over a flattened action space and only
+  makes sense inside the gym/PettingZoo training environment.
+
+The canonical contract
+----------------------
+:class:`BlokusAgent` is the canonical, ``runtime_checkable`` Protocol. Every
+gameplay agent already satisfies it because it only requires ``select_action``.
+Richer call sites (anything that needs a time budget, a seed, or diagnostics)
+should go through :func:`decide`, which returns an :class:`AgentDecision`
+(move + stats) and transparently routes to ``choose_move`` when the agent
+exposes the deploy protocol, or to ``select_action`` otherwise.
+
+New code should depend on :class:`BlokusAgent` / :func:`decide` rather than
+calling ``select_action``/``choose_move``/``act`` directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, Tuple, runtime_checkable
+
+from engine.board import Board, Player
+from engine.move_generator import Move
+
+# Default per-move thinking budget (ms) used when a context does not set one but
+# the underlying agent exposes the deploy ``choose_move`` protocol.
+DEFAULT_TIME_BUDGET_MS = 1000
+
+
+@runtime_checkable
+class BlokusAgent(Protocol):
+    """Canonical move-selection contract for Blokus agents.
+
+    The single required method is :meth:`select_action`. It is intentionally the
+    smallest universal contract — every gameplay agent in the repo implements it,
+    so ``isinstance(agent, BlokusAgent)`` is the canonical conformance check.
+
+    Agents that also want to advertise a time budget and richer telemetry may
+    additionally implement the deploy protocol method
+    ``choose_move(board, player, legal_moves, time_budget_ms) -> (Move | None, dict)``;
+    :func:`decide` will prefer it automatically when present.
+    """
+
+    def select_action(
+        self,
+        board: Board,
+        player: Player,
+        legal_moves: List[Move],
+    ) -> Optional[Move]:
+        """Return one move for ``player`` given ``legal_moves`` (or ``None``)."""
+        ...
+
+
+@dataclass
+class AgentDecisionContext:
+    """Optional context handed to :func:`decide`.
+
+    All fields are optional so the canonical call works for the simplest agents.
+
+    Attributes
+    ----------
+    time_budget_ms:
+        Soft per-move thinking budget in milliseconds. Forwarded to deploy
+        agents via ``choose_move``; for native agents that expose a
+        ``time_limit`` attribute (e.g. :class:`mcts.mcts_agent.MCTSAgent`) it is
+        applied before selection so the same budget controls search depth.
+    seed:
+        Per-decision random seed. Applied via the agent's ``set_seed`` method
+        when available (no-op for deterministic agents).
+    collect_diagnostics:
+        When ``True``, :func:`decide` gathers per-move telemetry (via
+        ``get_action_info``/``get_search_trace``) into :class:`AgentDecision`.
+    extra:
+        Free-form passthrough for adapter-specific hints. Never required.
+    """
+
+    time_budget_ms: Optional[int] = None
+    seed: Optional[int] = None
+    collect_diagnostics: bool = False
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AgentDecision:
+    """Result of a canonical :func:`decide` call.
+
+    ``move`` is ``None`` when the agent has no legal move to play. ``stats``
+    holds optional diagnostics (search iterations, visit counts, budget tier,
+    search trace, ...); it is always a dict, possibly empty.
+    """
+
+    move: Optional[Move]
+    stats: Dict[str, Any] = field(default_factory=dict)
+
+
+def is_gameplay_agent(agent: Any) -> bool:
+    """True if ``agent`` exposes the deploy ``choose_move`` protocol.
+
+    Mirrors :func:`webapi.gameplay_agent_factory.is_gameplay_adapter` but is kept
+    here so the canonical layer has no dependency on the web package.
+    """
+    return callable(getattr(agent, "choose_move", None)) and hasattr(
+        type(agent), "choose_move"
+    )
+
+
+def conforms(agent: Any) -> bool:
+    """True if ``agent`` satisfies the canonical :class:`BlokusAgent` contract."""
+    return isinstance(agent, BlokusAgent)
+
+
+def decide(
+    agent: Any,
+    board: Board,
+    player: Player,
+    legal_moves: List[Move],
+    context: Optional[AgentDecisionContext] = None,
+) -> AgentDecision:
+    """Canonical front door for asking any agent to choose a move.
+
+    Routing:
+
+    * If ``agent`` exposes the deploy ``choose_move`` protocol, it is called with
+      the requested (or default) time budget and its ``(move, stats)`` tuple is
+      returned verbatim.
+    * Otherwise the native ``select_action`` is used. The time budget is applied
+      to ``agent.time_limit`` when the agent supports it, and diagnostics are
+      gathered from ``get_action_info``/``get_search_trace`` when requested.
+
+    Returns ``AgentDecision(move=None, stats={})`` when there are no legal moves.
+    """
+    context = context or AgentDecisionContext()
+
+    if not legal_moves:
+        return AgentDecision(move=None, stats={})
+
+    if context.seed is not None and hasattr(agent, "set_seed"):
+        agent.set_seed(int(context.seed))
+
+    if is_gameplay_agent(agent):
+        budget = (
+            int(context.time_budget_ms)
+            if context.time_budget_ms is not None
+            else DEFAULT_TIME_BUDGET_MS
+        )
+        move, stats = agent.choose_move(board, player, legal_moves, budget)
+        return AgentDecision(move=move, stats=dict(stats or {}))
+
+    # Native select_action path.
+    if context.time_budget_ms is not None and hasattr(agent, "time_limit"):
+        agent.time_limit = max(int(context.time_budget_ms), 1) / 1000.0
+
+    move = agent.select_action(board, player, legal_moves)
+
+    stats: Dict[str, Any] = {}
+    if context.collect_diagnostics:
+        get_info = getattr(agent, "get_action_info", None)
+        if callable(get_info):
+            info = get_info()
+            if isinstance(info, dict) and isinstance(info.get("stats"), dict):
+                stats.update(info["stats"])
+        get_trace = getattr(agent, "get_search_trace", None)
+        if callable(get_trace):
+            trace = get_trace()
+            if trace:
+                stats["searchTrace"] = trace
+
+    return AgentDecision(move=move, stats=stats)
+
+
+def as_choose_move(
+    agent: Any,
+    board: Board,
+    player: Player,
+    legal_moves: List[Move],
+    time_budget_ms: Optional[int] = None,
+) -> Tuple[Optional[Move], Dict[str, Any]]:
+    """Compatibility shim returning the deploy ``(move, stats)`` tuple.
+
+    Lets call sites that still expect the gameplay protocol's tuple shape drive
+    *any* canonical agent without caring which native convention it uses.
+    """
+    decision = decide(
+        agent,
+        board,
+        player,
+        legal_moves,
+        AgentDecisionContext(time_budget_ms=time_budget_ms, collect_diagnostics=True),
+    )
+    return decision.move, decision.stats

--- a/docs/00-overview/DOCUMENTATION_INDEX.md
+++ b/docs/00-overview/DOCUMENTATION_INDEX.md
@@ -23,7 +23,7 @@
 - [Product Brief](../01-product/PRODUCT_BRIEF.md) · [Feature Inventory](../01-product/FEATURE_INVENTORY.md) · [Current Behavior](../01-product/CURRENT_BEHAVIOR.md) · [User Flows](../01-product/USER_FLOWS.md) · [Screen Inventory](../01-product/SCREEN_INVENTORY.md)
 
 ### 02 — Architecture
-- [Architecture](../02-architecture/ARCHITECTURE.md) · [System Map](../02-architecture/SYSTEM_MAP.md) · [Data Model](../02-architecture/DATA_MODEL.md) · [API Inventory](../02-architecture/API_INVENTORY.md) · [State Management](../02-architecture/STATE_MANAGEMENT.md) · [Integrations](../02-architecture/INTEGRATIONS.md)
+- [Architecture](../02-architecture/ARCHITECTURE.md) · [System Map](../02-architecture/SYSTEM_MAP.md) · [Agent Interface](../02-architecture/AGENT_INTERFACE.md) · [Data Model](../02-architecture/DATA_MODEL.md) · [API Inventory](../02-architecture/API_INVENTORY.md) · [State Management](../02-architecture/STATE_MANAGEMENT.md) · [Integrations](../02-architecture/INTEGRATIONS.md)
 
 ### 03 — Implementation
 - [Codebase Inventory](../03-implementation/CODEBASE_INVENTORY.md) · [Route Inventory](../03-implementation/ROUTE_INVENTORY.md) · [Config & Environment](../03-implementation/CONFIG_AND_ENVIRONMENT.md) · [Testing Strategy](../03-implementation/TESTING_STRATEGY.md)

--- a/docs/02-architecture/AGENT_INTERFACE.md
+++ b/docs/02-architecture/AGENT_INTERFACE.md
@@ -1,0 +1,177 @@
+# Agent Interface
+
+**Status:** Implemented (Phase 3 — Standardize Agent Interface + Web-Ready Champion Contract)
+
+This document defines the **canonical agent contract** for the MCTS Laboratory /
+Blokus codebase, explains why several older calling conventions exist, which
+adapters remain, and how agents are built for the arena, the backend, and the
+registry-backed champion.
+
+---
+
+## 1. The canonical contract
+
+The canonical contract lives in [`agents/interface.py`](../../agents/interface.py).
+
+### `BlokusAgent` (Protocol)
+
+```python
+@runtime_checkable
+class BlokusAgent(Protocol):
+    def select_action(
+        self,
+        board: Board,
+        player: Player,
+        legal_moves: list[Move],
+    ) -> Move | None:
+        ...
+```
+
+`select_action` is the **smallest universal contract** — given a board, the
+player to move, and the legal moves, return one move (or `None` when there is
+nothing to play). Every real gameplay agent already implements it, so
+`isinstance(agent, BlokusAgent)` is the canonical conformance check.
+
+### `AgentDecisionContext`
+
+Optional, all-default context for richer call sites:
+
+| Field | Meaning |
+|---|---|
+| `time_budget_ms` | Soft per-move thinking budget. Forwarded to deploy agents; applied to `agent.time_limit` for native MCTS. |
+| `seed` | Per-decision seed, applied via `set_seed` when present. |
+| `collect_diagnostics` | When `True`, gather per-move telemetry into the decision. |
+| `extra` | Free-form passthrough; never required. |
+
+### `AgentDecision`
+
+```python
+@dataclass
+class AgentDecision:
+    move: Move | None
+    stats: dict[str, Any]
+```
+
+`move` is `None` when there is no legal move. `stats` is always a dict (possibly
+empty): search iterations, visit counts, budget tier, search trace, etc.
+
+### `decide(...)` — the front door
+
+```python
+def decide(agent, board, player, legal_moves, context=None) -> AgentDecision
+```
+
+`decide` is what new code should call. It:
+
+1. Returns `AgentDecision(None, {})` immediately when `legal_moves` is empty.
+2. Applies `context.seed` via `set_seed` when supported.
+3. If the agent exposes the **deploy** `choose_move` protocol
+   (`is_gameplay_agent(agent)` is `True`), calls it with the requested/default
+   budget and returns its `(move, stats)` verbatim.
+4. Otherwise calls native `select_action`, pushing `time_budget_ms` onto
+   `agent.time_limit` when available and collecting diagnostics on request.
+
+`as_choose_move(...)` is a thin compatibility shim returning the legacy
+`(move, stats)` tuple for call sites that still expect that shape.
+
+---
+
+## 2. Why the old conventions existed
+
+The repo grew **three** agent calling conventions. The canonical layer does not
+delete them — it unifies them.
+
+| Convention | Signature | Origin / role |
+|---|---|---|
+| `select_action` | `(board, player, legal_moves) -> Move \| None` | The **native** method on `RandomAgent`, `HeuristicAgent`, `MCTSAgent`. The minimal position→move contract. |
+| `choose_move` | `(board, player, legal_moves, time_budget_ms) -> (Move \| None, dict)` | The **deploy/web** protocol (`agents/gameplay_protocol.py`). Adds a per-move time budget and a diagnostics dict needed when serving moves over a websocket. |
+| `act` | `(observation, legal_mask, env) -> int \| None` | The **legacy RL-era** protocol (`agents/registry.py`, `league/`). Index-based over a flattened action space; only meaningful inside the gym/PettingZoo training env. |
+
+`select_action` became the de-facto standard because all three production agents
+implement it; `choose_move` layered budget + telemetry on top for deployment;
+`act` is an RL artifact retained only for the league code.
+
+---
+
+## 3. Which adapters remain
+
+All preserved behind thin adapters — no agent was rewritten.
+
+| Adapter | Location | Bridges |
+|---|---|---|
+| `_SelectActionAdapter` | `analytics/tournament/arena_runner.py` | native `select_action` → arena `choose_move(board, player, legal_moves, thinking_ms) -> (move, stats)` |
+| `_ChooseMoveAdapter` | `analytics/tournament/arena_runner.py` | deploy gameplay agents inside the arena |
+| `_MCTSGameplayAdapter` / `_ChallengeChampionGameplayAdapter` | `webapi/gameplay_agent_factory.py` | `MCTSAgent.select_action` → deploy `choose_move` with adaptive budgets |
+| `RandomAgentAdapter` / `HeuristicAgentAdapter` / `MCTSAgentAdapter` / `RLPolicyAgent` | `agents/registry.py` | native agents → legacy RL `act(observation, legal_mask, env)` |
+| `is_gameplay_agent` / `as_choose_move` | `agents/interface.py` | canonical detection + `(move, stats)` shim |
+
+---
+
+## 4. How arena agents are built
+
+`analytics/tournament/arena_runner.build_agent(AgentConfig, seed)` constructs an
+`_ArenaAgentAdapter`:
+
+- `random` / `heuristic` / `mcts` → wrapped in `_SelectActionAdapter`.
+- `challenge_champion_gameplay` → wrapped in `_ChooseMoveAdapter`.
+
+The arena run loop drives every agent uniformly via
+`agent.choose_move(board, player, legal_moves, thinking_time_ms) -> (move, stats)`,
+so the adapters are the unification point. This behaviour is unchanged by Phase 3.
+
+---
+
+## 5. How web/backend agents are built
+
+`webapi/gameplay_agent_factory.build_deploy_gameplay_agent(agent_type, config)`
+returns deploy adapters that satisfy `GameplayAgentProtocol.choose_move`. The
+FastAPI request path (`webapi/app.py`) calls `choose_move` when the agent is a
+gameplay adapter and falls back to `select_action` otherwise — exactly the
+routing `decide()` performs. New backend code should prefer
+`agents.interface.decide(...)`.
+
+---
+
+## 6. How the champion agent is loaded
+
+The registry-backed champion contract lives in
+[`agents/champion.py`](../../agents/champion.py).
+
+```python
+from agents.champion import load_champion, NoValidatedChampionError
+
+handle = load_champion()          # raises if no validated champion exists
+agent  = handle.agent             # canonical, choose_move-capable
+meta   = handle.metadata          # validation metadata
+```
+
+`load_champion()`:
+
+1. Reads `data/champion_registry.json` and resolves `current_version`.
+2. **Validates** the version is a real, gauntlet-promoted champion: it must carry
+   `gate_pass == True`, a resolvable `config_path`, and non-null `avg_win_rate` /
+   `avg_trueskill_mu`. The shipped seed `v1` entry (null metrics, no `gate_pass`)
+   is therefore **not** loadable — by design.
+3. Resolves the config path and builds the agent through the arena's vetted
+   `build_agent`, so the served champion is exactly the validated agent.
+4. Surfaces `ChampionMetadata`: `validation_date`, `gauntlet_run_path`,
+   `win_rate`, `trueskill_mu` / `trueskill_conservative`, `total_games`,
+   `config_path`, `params`, `promotion_reason`.
+
+`NoValidatedChampionError` is raised with a clear reason when no validated
+champion exists. **The loader never silently falls back to an unvalidated
+champion.** Promote one with `scripts/champion_gauntlet.py --promote`.
+
+---
+
+## 7. What future contributors should use
+
+- **Implement** new agents by providing `select_action(board, player, legal_moves)`.
+  That alone makes them canonical `BlokusAgent`s.
+- **Call** agents through `agents.interface.decide(agent, board, player,
+  legal_moves, context)` — never reach for `select_action` / `choose_move` /
+  `act` directly in new code.
+- **Serve the champion** via `agents.champion.load_champion()`; treat
+  `NoValidatedChampionError` as a hard failure, not a reason to fall back.
+- **Do not** add a fourth convention. Add an adapter if a foreign interface must
+  be bridged.

--- a/tests/test_agent_interface_contract.py
+++ b/tests/test_agent_interface_contract.py
@@ -1,0 +1,250 @@
+"""Tests for the canonical agent interface and the champion contract.
+
+These are deliberately lightweight and deterministic — no tournaments are run.
+They verify:
+
+1. RandomAgent / HeuristicAgent / MCTSAgent conform to ``BlokusAgent``.
+2. :func:`agents.interface.decide` returns canonical decisions, including the
+   ``None`` move on empty legal moves.
+3. The arena adapter preserves existing ``choose_move`` behaviour.
+4. The champion loader fails clearly when the registry has no validated champion.
+5. The champion loader works when the registry has valid metadata + config.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from engine.board import Board, Player
+from engine.game import BlokusGame
+
+from agents.random_agent import RandomAgent
+from agents.heuristic_agent import HeuristicAgent
+from mcts.mcts_agent import MCTSAgent
+
+from agents.interface import (
+    AgentDecision,
+    AgentDecisionContext,
+    BlokusAgent,
+    conforms,
+    decide,
+    is_gameplay_agent,
+)
+from agents.champion import (
+    ChampionHandle,
+    ChampionMetadata,
+    NoValidatedChampionError,
+    load_champion,
+    load_champion_metadata,
+)
+
+
+def _fresh_position():
+    game = BlokusGame()
+    player = game.get_current_player()
+    legal_moves = game.get_legal_moves(player)
+    return game.board, player, legal_moves
+
+
+def _move_key(move):
+    return (move.piece_id, move.orientation, move.anchor_row, move.anchor_col)
+
+
+def _legal_keys(legal_moves):
+    # Move has no value equality; compare by identifying tuple like the rest of
+    # the test-suite does.
+    return {_move_key(m) for m in legal_moves}
+
+
+class TestCanonicalConformance(unittest.TestCase):
+    """All real gameplay agents satisfy the canonical BlokusAgent contract."""
+
+    def test_random_agent_conforms(self):
+        agent = RandomAgent(seed=1)
+        self.assertIsInstance(agent, BlokusAgent)
+        self.assertTrue(conforms(agent))
+
+    def test_heuristic_agent_conforms(self):
+        agent = HeuristicAgent(seed=1)
+        self.assertIsInstance(agent, BlokusAgent)
+        self.assertTrue(conforms(agent))
+
+    def test_mcts_agent_conforms(self):
+        agent = MCTSAgent(iterations=5, seed=1)
+        self.assertIsInstance(agent, BlokusAgent)
+        self.assertTrue(conforms(agent))
+
+
+class TestDecide(unittest.TestCase):
+    """The decide() front door behaves canonically for every agent."""
+
+    def test_decide_returns_legal_move_random(self):
+        board, player, legal_moves = _fresh_position()
+        decision = decide(RandomAgent(seed=7), board, player, legal_moves)
+        self.assertIsInstance(decision, AgentDecision)
+        self.assertIn(_move_key(decision.move), _legal_keys(legal_moves))
+
+    def test_decide_returns_legal_move_heuristic(self):
+        board, player, legal_moves = _fresh_position()
+        decision = decide(HeuristicAgent(seed=7), board, player, legal_moves)
+        self.assertIn(_move_key(decision.move), _legal_keys(legal_moves))
+
+    def test_decide_returns_legal_move_mcts(self):
+        board, player, legal_moves = _fresh_position()
+        decision = decide(MCTSAgent(iterations=10, seed=7), board, player, legal_moves)
+        self.assertIn(_move_key(decision.move), _legal_keys(legal_moves))
+
+    def test_decide_none_on_empty_legal_moves(self):
+        board, player, _ = _fresh_position()
+        decision = decide(RandomAgent(seed=7), board, player, [])
+        self.assertIsNone(decision.move)
+        self.assertEqual(decision.stats, {})
+
+    def test_decide_collects_mcts_diagnostics(self):
+        board, player, legal_moves = _fresh_position()
+        context = AgentDecisionContext(collect_diagnostics=True)
+        decision = decide(MCTSAgent(iterations=10, seed=7), board, player, legal_moves, context)
+        # MCTSAgent.get_action_info exposes a stats dict.
+        self.assertIsInstance(decision.stats, dict)
+        self.assertIn("iterations_run", decision.stats)
+
+    def test_decide_applies_time_budget_to_mcts(self):
+        board, player, legal_moves = _fresh_position()
+        agent = MCTSAgent(iterations=10000, seed=7)
+        context = AgentDecisionContext(time_budget_ms=50)
+        decide(agent, board, player, legal_moves, context)
+        # The budget was pushed onto the agent's time_limit (seconds).
+        self.assertAlmostEqual(agent.time_limit, 0.05, places=6)
+
+    def test_native_agents_are_not_gameplay_agents(self):
+        self.assertFalse(is_gameplay_agent(RandomAgent(seed=1)))
+        self.assertFalse(is_gameplay_agent(MCTSAgent(iterations=5, seed=1)))
+
+
+class TestArenaAdapterPreserved(unittest.TestCase):
+    """The arena adapter still wraps select_action into (move, stats)."""
+
+    def test_select_action_adapter_choose_move(self):
+        from analytics.tournament.arena_runner import _SelectActionAdapter
+
+        board, player, legal_moves = _fresh_position()
+        adapter = _SelectActionAdapter(RandomAgent(seed=3))
+        self.assertTrue(is_gameplay_agent(adapter))
+        move, stats = adapter.choose_move(board, player, legal_moves, 1000)
+        self.assertIn(move, legal_moves)
+        self.assertIn("timeSpentMs", stats)
+
+    def test_decide_routes_through_gameplay_adapter(self):
+        from analytics.tournament.arena_runner import _SelectActionAdapter
+
+        board, player, legal_moves = _fresh_position()
+        adapter = _SelectActionAdapter(RandomAgent(seed=3))
+        decision = decide(
+            adapter, board, player, legal_moves,
+            AgentDecisionContext(time_budget_ms=500),
+        )
+        self.assertIn(_move_key(decision.move), _legal_keys(legal_moves))
+        self.assertIn("timeSpentMs", decision.stats)
+
+
+def _write_registry(path: Path, entry: dict, current: str = "v1") -> None:
+    registry = {
+        "current_version": current,
+        "versions": {current: entry} if entry is not None else {},
+        "iterations": [],
+        "snapshot_csv_paths": [],
+        "total_games_played": int(entry.get("total_games_played", 0)) if entry else 0,
+    }
+    path.write_text(json.dumps(registry, indent=2), encoding="utf-8")
+
+
+class TestChampionLoaderFailsClearly(unittest.TestCase):
+    """The loader refuses to serve an unvalidated champion."""
+
+    def test_seed_registry_with_null_metrics_is_rejected(self):
+        with TemporaryDirectory() as tmp:
+            reg = Path(tmp) / "registry.json"
+            # Mirrors the shipped seed entry: null metrics, no gate_pass/config.
+            _write_registry(reg, {
+                "promoted_at": "2026-04-29T00:00:00+00:00",
+                "params": {"rollout_policy": "random"},
+                "avg_win_rate": None,
+                "avg_trueskill_mu": None,
+            })
+            with self.assertRaises(NoValidatedChampionError):
+                load_champion_metadata(reg)
+
+    def test_missing_registry_raises(self):
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(NoValidatedChampionError):
+                load_champion_metadata(Path(tmp) / "does_not_exist.json")
+
+    def test_no_current_version_raises(self):
+        with TemporaryDirectory() as tmp:
+            reg = Path(tmp) / "registry.json"
+            reg.write_text(json.dumps({"current_version": None, "versions": {}}), encoding="utf-8")
+            with self.assertRaises(NoValidatedChampionError):
+                load_champion_metadata(reg)
+
+
+class TestChampionLoaderHappyPath(unittest.TestCase):
+    """The loader resolves metadata + builds an agent for a validated champion."""
+
+    def _validated_entry(self, config_path: str) -> dict:
+        return {
+            "promoted_at": "2026-06-17T00:00:00+00:00",
+            "promoted_from": None,
+            "promotion_reason": "test fixture",
+            "champion_name": "test_champion",
+            "config_path": config_path,
+            "params": {"seed": 0},
+            "avg_win_rate": 0.42,
+            "win_rate_ci": {"lower": 0.30, "upper": 0.55},
+            "avg_trueskill_mu": 27.5,
+            "trueskill_sigma": 2.1,
+            "trueskill_conservative": 21.2,
+            "avg_score": 61.0,
+            "total_games_played": 120,
+            "seeds": [1, 2, 3],
+            "validation_date": "2026-06-17T00:00:00+00:00",
+            "gauntlet_run_path": "analytics/tournament/runs/gauntlet_test",
+            "comparison_opponents": ["a", "b", "c"],
+            "gate_pass": True,
+        }
+
+    def test_metadata_resolves(self):
+        with TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "champ.json"
+            cfg.write_text(json.dumps({"type": "random", "thinking_time_ms": 100}), encoding="utf-8")
+            reg = Path(tmp) / "registry.json"
+            _write_registry(reg, self._validated_entry(str(cfg)))
+
+            meta = load_champion_metadata(reg)
+            self.assertIsInstance(meta, ChampionMetadata)
+            self.assertEqual(meta.champion_name, "test_champion")
+            self.assertEqual(meta.win_rate, 0.42)
+            self.assertEqual(meta.trueskill_mu, 27.5)
+            self.assertEqual(meta.total_games, 120)
+            self.assertEqual(meta.gauntlet_run_path, "analytics/tournament/runs/gauntlet_test")
+            self.assertIn("test_champion", meta.summary())
+
+    def test_loads_and_builds_agent(self):
+        # Use a cheap 'random' champion so the test stays fast & deterministic.
+        with TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "champ.json"
+            cfg.write_text(json.dumps({"type": "random", "thinking_time_ms": 100}), encoding="utf-8")
+            reg = Path(tmp) / "registry.json"
+            _write_registry(reg, self._validated_entry(str(cfg)))
+
+            handle = load_champion(reg, seed=5)
+            self.assertIsInstance(handle, ChampionHandle)
+            # The built agent is canonical-drivable.
+            self.assertTrue(is_gameplay_agent(handle.agent))
+            board, player, legal_moves = _fresh_position()
+            decision = decide(handle.agent, board, player, legal_moves)
+            self.assertIn(_move_key(decision.move), _legal_keys(legal_moves))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Unify the repo's three historical agent calling conventions behind one
canonical contract while preserving all existing behavior through thin
adapters.

- agents/interface.py: canonical BlokusAgent Protocol (select_action),
  AgentDecisionContext / AgentDecision, and a decide() front door that
  routes to the deploy choose_move protocol when present and to native
  select_action otherwise (time budget, seed, diagnostics, None handling).
  is_gameplay_agent() / as_choose_move() bridge legacy call sites.
- agents/champion.py: registry-backed champion loader. load_champion()
  resolves the validated champion from data/champion_registry.json (config
  path, validation date, gauntlet run path, win rate, TrueSkill, total
  games), builds it via the arena's vetted build_agent, and raises
  NoValidatedChampionError rather than ever serving an unvalidated
  champion (the seed v1 entry with null metrics is correctly rejected).
- tests/test_agent_interface_contract.py: Random/Heuristic/MCTS conform to
  BlokusAgent; decide() behavior incl. None on empty moves; arena adapter
  preserved; champion loader fails clearly and loads a valid registry.
- docs/02-architecture/AGENT_INTERFACE.md + index + FEATURES.md.

No MCTS, arena-loop, or backend internals were rewritten.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P7Cz11i8ay66mQcw5bKNoR