### PR TITLE
Run training every 6 hours; add explicit weak-opponent sprinkle

### DIFF
--- a/.github/workflows/nightly-mcts-training.yml
+++ b/.github/workflows/nightly-mcts-training.yml
@@ -1,16 +1,18 @@
 name: nightly-mcts-training
 
-# Durable, resumable nightly Blokus MCTS self-play training.
+# Durable, resumable Blokus MCTS self-play training.
 #
-# Runs every night, RESUMES from the committed durable state under training/state/,
+# Runs every 6 hours, RESUMES from the committed durable state under training/state/,
 # trains within a wall-clock budget, evaluates + (internally) promotes a candidate,
 # regenerates reports, commits the updated state back to the repo, and ALWAYS emails
 # a summary — on success and on failure. See docs/03-implementation/NIGHTLY_TRAINING.md.
 
 on:
   schedule:
-    # 03:00 UTC nightly. (cron is always UTC.)
-    - cron: "0 3 * * *"
+    # Every 6 hours at :00 (00/06/12/18 UTC) — ~20h/day of training with a ~1h
+    # buffer between runs for eval, reports, commit-back, and email. The
+    # `concurrency` block below queues (does not cancel) any overlap.
+    - cron: "0 */6 * * *"
   workflow_dispatch:
     inputs:
       hours:

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -150,12 +150,13 @@
 - Atomic state persistence (tmp + `os.replace`) + append-only JSONL history for partial-progress durability — `training/state_store.py`
 - Append-only SQLite rating timeline (Elo + TrueSkill per agent per run; never overwritten) with cross-run rating seeding — `training/ratings_db.py`
 - Candidate generation via Layer-6 evaluator-weight re-fit on accumulated self-play snapshots; rotating-opponent evaluation battery (vs champion, random, heuristic, previous + historical champions) under the 4-agent arena rule; conservative 6-gate promotion (reuses `analytics/tournament/gauntlet.py`) — `training/selfplay_core.py`
+- Elo-improvement-oriented per-generation challenger mix: heuristic + recent checkpoint + MCTS variant, with a `WEAK_OPPONENT_PROB`=0.2 sprinkle of `random` to anchor the bottom of the rating ladder and broaden the snapshot corpus — `scripts/champion_loop.py` (`select_challengers`)
 - Internal-only champion promotion (updates `training/state/`; opt-in `--promote-registry` to also update the deployed `data/champion_registry.json`) — `training/nightly_run.py`
 - Human-strength Elo estimation (1200/1500/1700 anchors) with moving-average trend, uncertainty band, and no-fabricated-confidence rule — `training/human_estimate.py`
 - Nightly status report (`training/status.md`: Summary / Daily Progress / Baseline Results / Human Strength Estimate / Training Trends / Risks) — `training/status_report.py`
 - Deterministic diagnostics (regression, stagnation, rating instability, refit health, promotion drought) → `training/reports/latest_diagnosis.md` (always written) — `training/diagnostics.py`
 - SMTP email digest from repo secrets, for both success and failure (graceful skip when unconfigured) — `training/email_summary.py`
-- Nightly GitHub Actions workflow (cron + manual dispatch, concurrency guard, commit-back of durable state, always-send email) — `.github/workflows/nightly-mcts-training.yml`
+- GitHub Actions training workflow: cron `0 */6 * * *` (every 6 hours, ~4 runs/day) + manual dispatch, concurrency guard (queues rather than cancels), commit-back of durable state, always-send email — `.github/workflows/nightly-mcts-training.yml`
 - Pipeline guide (architecture, operations, self-hosted runner fallback, storage growth) — `docs/03-implementation/NIGHTLY_TRAINING.md`
 
 ## Testing

--- a/docs/03-implementation/NIGHTLY_TRAINING.md
+++ b/docs/03-implementation/NIGHTLY_TRAINING.md
@@ -1,11 +1,14 @@
-# Durable Nightly MCTS Training Pipeline
+# Durable MCTS Training Pipeline
 
 Status: **Implemented**
 
 A continuously-improving, AlphaZero-spirit self-play training system that runs
-every night, **resumes from durable on-disk state**, generates improved candidate
-agents, promotes them when statistically justified, tracks Elo + TrueSkill over
-time, estimates progress toward human-level play, and emails a concise summary.
+**every 6 hours** (00/06/12/18 UTC), **resumes from durable on-disk state**,
+generates improved candidate agents, promotes them when statistically justified,
+tracks Elo + TrueSkill over time, estimates progress toward human-level play,
+and emails a concise summary. The pipeline was originally daily; running four
+times a day takes advantage of GitHub Actions' unlimited free minutes on public
+repos (the file/dir names still say "nightly" for historical compatibility).
 
 The cardinal rule — and the reason previous nightly attempts failed — is that
 **all training memory lives on disk under `training/state/`**. Every run loads it,
@@ -51,7 +54,13 @@ Reports also live at `training/status.md` and `training/reports/latest_diagnosis
    generations until the wall-clock budget (`--hours × 0.7`) is spent, writing
    state atomically and appending to `history.jsonl` **after each generation**
    (so a crash never loses completed generations). Each generation grows the
-   shared snapshot corpus `data/champion_snapshots.csv`.
+   shared snapshot corpus `data/champion_snapshots.csv`. Each generation's
+   3-challenger lineup is Elo-improvement oriented (see :func:`select_challengers`
+   in `scripts/champion_loop.py`): slot 0 is always `heuristic`; slot 1 is a
+   recent learned checkpoint; slot 2 is an MCTS variant, with a small
+   `WEAK_OPPONENT_PROB` (default 0.2) chance of being swapped for `random` —
+   the explicit "occasional weak agent" that anchors the bottom of the rating
+   ladder and broadens the snapshot corpus.
 4. **Candidate:** re-fit evaluator weights on the corpus → candidate = champion +
    new per-phase weights. (No candidate until ≥200 snapshot rows exist.)
 5. **Evaluate:** a battery of 4-agent arenas — `[champion, candidate, opp_A, opp_B]`
@@ -82,10 +91,18 @@ python -m training.email_summary --failed   # failure
 
 ## GitHub Actions (`.github/workflows/nightly-mcts-training.yml`)
 
-- `schedule: cron "0 3 * * *"` (03:00 UTC) + `workflow_dispatch` (manual, with
-  `hours`/`games_per_arena` inputs).
+- `schedule: cron "0 */6 * * *"` (every 6 hours at :00 UTC — 4 runs/day) +
+  `workflow_dispatch` (manual, with `hours`/`games_per_arena` inputs).
 - `concurrency: nightly-mcts-training`, `cancel-in-progress: false` — never two at
-  once, never kill an in-flight run.
+  once, never kill an in-flight run. With the 5-hour default budget and a
+  6-hour cadence there is a ~1h buffer between runs; if one runs long the next
+  scheduled tick queues rather than starting concurrently.
+- **Counter semantics under multi-run cadence:** `state["days_trained"]`
+  increments once per *run*, not once per calendar day. With 4 runs/day it now
+  reads as "training cycles completed" rather than literal days; the
+  human-strength projection's per-day rate is similarly a per-run rate. Both
+  numbers are still monotonic and useful for trend visualisation; only the
+  unit label is loose.
 - Steps: checkout → install → **train** (`continue-on-error`) → reports
   (`if: always()`) → optional Claude augmentation → **commit state back** →
   **email** (`if: always()`, `--failed` when training failed) → mark job failed.

--- a/scripts/champion_loop.py
+++ b/scripts/champion_loop.py
@@ -72,6 +72,12 @@ WEIGHT_SCALE = 0.30
 # Number of most-recent checkpoints to keep in the active pool
 MAX_CHECKPOINTS_IN_POOL = 3
 
+# Probability of swapping the "MCTS variant" slot for a weak random baseline
+# each generation. Mostly-strong opponents drive Elo improvement; an occasional
+# weak agent anchors the bottom of the rating ladder and diversifies the
+# snapshot corpus with easy-win trajectories.
+WEAK_OPPONENT_PROB = 0.2
+
 # Champion agent name (stable across all generations for TrueSkill tracking)
 CHAMPION_ID = "champion"
 
@@ -221,12 +227,20 @@ def select_challengers(
     base_params: Dict[str, Any],
     rng: random.Random,
 ) -> List[Dict[str, Any]]:
-    """Choose 3 challengers for this generation.
+    """Choose 3 challengers for this generation (Elo-improvement oriented).
 
     Strategy:
-      - Slot 0: always heuristic (strong baseline)
-      - Slot 1: random checkpoint if available, else random MCTS variant
-      - Slot 2: random MCTS variant (different from slot 1 if possible)
+      - Slot 0: always heuristic — strong, stable baseline; anchors the ladder
+        near "good play" so champion Elo gains track real skill, not drift.
+      - Slot 1: recent checkpoint (a learned, historically-strong opponent),
+        falling back to ``random`` only on cold start when no checkpoints exist.
+      - Slot 2: with probability ``WEAK_OPPONENT_PROB``, a ``random`` baseline
+        (occasional weak agent — anchors the bottom of the ladder and broadens
+        the snapshot corpus with closing-out trajectories). Otherwise an MCTS
+        variant — strong and exploratory — distinct from slots 0/1.
+
+    The mix is mostly-strong on every generation; the random sprinkle is an
+    explicit calibration signal, not a fallback.
     """
     challengers: List[Dict[str, Any]] = []
 
@@ -244,14 +258,17 @@ def select_challengers(
     else:
         challengers.append(_build_baseline_agent_config("random"))
 
-    # Slot 2: MCTS variant (sample one not already in challengers)
+    # Slot 2: occasional weak sprinkle OR MCTS variant (distinct from slots 0/1).
     used_ids = {c["name"] for c in challengers}
-    available_variants = [v for v in MCTS_VARIANTS if v["id"] not in used_ids]
-    if available_variants:
-        variant = rng.choice(available_variants)
-        challengers.append(_build_variant_agent_config(base_params, variant))
-    else:
+    if rng.random() < WEAK_OPPONENT_PROB and "random" not in used_ids:
         challengers.append(_build_baseline_agent_config("random"))
+    else:
+        available_variants = [v for v in MCTS_VARIANTS if v["id"] not in used_ids]
+        if available_variants:
+            variant = rng.choice(available_variants)
+            challengers.append(_build_variant_agent_config(base_params, variant))
+        else:
+            challengers.append(_build_baseline_agent_config("random"))
 
     return challengers
 


### PR DESCRIPTION
- Workflow cron `0 3 * * *` -> `0 */6 * * *` (4 runs/day, ~20h/day of
  training); 5h default budget + existing concurrency queue gives ~1h
  buffer between runs and never overlaps.
- `select_challengers` now mixes mostly-strong opponents (heuristic +
  recent checkpoint + MCTS variant) with a `WEAK_OPPONENT_PROB`=0.2
  sprinkle of `random` in slot 2 to anchor the bottom of the rating
  ladder and broaden the snapshot corpus with closing-out games.
- Doc + FEATURES updates including the days_trained semantics caveat
  under the new cadence.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xgy9hBBLMxGMHFJiicq2qC