### PR TITLE
Add optional rich leaf evaluator (45-feature TD value at MCTS leaves)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -29,6 +29,7 @@
 - Adaptive rollout cutoff depth based on branching factor (Layer 9) — `mcts/mcts_agent.py`
 - UCT sufficiency threshold (Layer 9) — `mcts/mcts_agent.py`
 - Loss avoidance for catastrophic nodes (Layer 9) — `mcts/mcts_agent.py`
+- Rich leaf evaluator: optional 45-feature TD-learned linear value model evaluated **only at MCTS leaves** (once per simulation, never per rollout step), unlocking the rich features the 8-feature serving evaluator discards (`score_margin_vs_leader`, `rank_so_far`, mobility, territory). Cost-tiered feature subsets (`score` ≈0.8 ms/leaf default, `no_opp_mobility` ≈7 ms, `full` ≈15–25 ms) drop the expensive opponent-mobility enumeration; loads `rich_phase_weights` from the TD artifact with graceful fallback to the 8-feature evaluator. Default OFF, enabled via `rich_leaf_eval_enabled` — `mcts/rich_leaf_evaluator.py`, `mcts/mcts_agent.py`, `training/rich_features.py` (`extract_leaf_features`, `LEAF_FEATURE_SUBSETS`), A/B harness `scripts/ab_rich_leaf.py`
 - Challenge Champion profile and adaptive human-play budget controller — `config/challenge_champion_config.json`, `mcts/champion_profile.py`, `mcts/adaptive_budget.py`
 - Learned evaluator (GBT model) for state scoring (Layer 2) — `mcts/learned_evaluator.py`
 - Move heuristic scoring — `mcts/move_heuristic.py`

--- a/analytics/tournament/arena_runner.py
+++ b/analytics/tournament/arena_runner.py
@@ -489,6 +489,10 @@ def build_agent(config: AgentConfig, seed: int) -> _ArenaAgentAdapter:
             sufficiency_threshold_enabled=bool(params.get("sufficiency_threshold_enabled", False)),
             loss_avoidance_enabled=bool(params.get("loss_avoidance_enabled", False)),
             loss_avoidance_threshold=float(params.get("loss_avoidance_threshold", -50.0)),
+            # Rich leaf evaluator (45-feature TD value at MCTS leaves)
+            rich_leaf_eval_enabled=bool(params.get("rich_leaf_eval_enabled", False)),
+            rich_leaf_weights_path=params.get("rich_leaf_weights_path"),
+            rich_leaf_feature_subset=str(params.get("rich_leaf_feature_subset", "score")),
         )
         return _SelectActionAdapter(agent)
 

--- a/docs/RICH_FEATURE_ANALYSIS.md
+++ b/docs/RICH_FEATURE_ANALYSIS.md
@@ -123,7 +123,7 @@ evaluate positions with more than 8 features, because they never reach it.
    a **richer leaf evaluator**: consume more of the 45 features at MCTS *leaf*
    nodes (called far less often than per-rollout-step eval), where the extra cost
    is affordable. This lets `rank_so_far` / mobility / territory actually
-   influence search. _Substantial work — deferred; see `tasks/TODO.md`._
+   influence search. **IMPLEMENTED 2026-06-26 — see §7.**
 3. **Prune dead/duplicate features.** `corner_count` duplicates `frontier_size`;
    `reachable_empty_squares` and `territory_enclosure_area` carry ~no signal.
    Pruning lowers collection cost and sharpens feature-importance reads. _Small._
@@ -135,10 +135,67 @@ evaluate positions with more than 8 features, because they never reach it.
    still be projected to 8 features. The architecture, not the learner, is the
    limit.
 
-> **Decision:** do **not** implement a rich-feature evaluator yet (per Phase-2
-> constraints). It is documented and prioritised in `tasks/TODO.md` and
-> `docs/LEARNING_ROADMAP.md` as the top medium-term item, gated on the comparison
-> harness confirming the bottleneck.
+> **Decision (superseded 2026-06-26):** the gate condition was met by
+> `exp_e1261b8e0c3b` (TD 25% vs regression 39%; the limiter is the 45→8
+> projection, not the learner), so the rich leaf evaluator is now **implemented**.
+> See §7.
+
+---
+
+## 7. The rich leaf evaluator (implemented 2026-06-26)
+
+The fix recommended above is now an **optional, default-OFF** feature.
+`mcts/rich_leaf_evaluator.py::RichLeafEvaluator` evaluates a node with the full
+45-feature TD value `Σ wᵢ·fᵢ + bias` using the per-phase `rich_phase_weights`
+already persisted in `training/state/td_evaluator_weights.json`. It is wired into
+`MCTSAgent._simulation` as a **leaf-only** call (flag `rich_leaf_eval_enabled`):
+invoked exactly once per simulation, replacing the rollout — **never** per
+rollout step. It loads the rich weights with graceful fallback to the 8-feature
+`BlokusStateEvaluator` when the artifact is missing/untrained.
+
+### The leaf-budget problem and the subset solution
+
+Full 45-feature extraction enumerates legal moves for **all four** players (the
+opponent-mobility features), measured at **~15–27 ms/leaf** — calling that even
+once per simulation would gut the iteration budget. So the evaluator selects a
+**cost tier** (`training.rich_features.LEAF_FEATURE_SUBSETS`); excluded features
+are zeroed, so their TD weights simply drop out of the dot product:
+
+| Subset | Features | Per-leaf cost | Drops |
+|---|---|---|---|
+| `full` | 45 | ~15–25 ms | nothing |
+| `no_opp_mobility` | 41 | ~7 ms | `opponent_mobility_{avg,max,min}`, `leader_mobility_pressure` (the all-player enumeration) |
+| **`score`** (default) | 27 | **~0.8 ms** | all legal-move enumeration + territory BFS |
+
+(measured with the engine's shared move generator at ~0.35 board occupancy;
+per-leaf cost rises with board density.)
+
+The `score` default is deliberate: the three **highest-signal** non-SE features
+(`score_margin_vs_leader` +0.725, `rank_so_far` +0.675,
+`score_margin_vs_next_player` +0.526; §2) are *cheap* — they need only square
+counts — while the expensive opponent-mobility features carry less signal. So the
+default tier recovers most of the lost signal at ~1/30th the cost of full
+extraction, and is the only tier cheaper than a rollout. The included features
+carry **identical values** to `extract_rich_features` (shared gated
+implementation, pinned by tests), so the TD-trained weights apply directly.
+
+### Validation
+
+A/B harness: `scripts/ab_rich_leaf.py` (baseline MCTS vs MCTS+rich-leaf, two of
+each per game, rotating seats, fixed iteration budget). It reports win rate, mean
+score, iterations/move, and per-leaf cost.
+
+**Measured so far.** Per-iteration cost (the decisive number): leaf eval
+*replaces* the rollout, so at a 334-legal-move position the baseline's full
+heuristic rollout costs **~273 ms/iter** vs rich-`score` **~4.5 ms/iter (~60×
+faster)**. Under a wall-clock / deterministic-arena budget that buys ~60× more
+iterations. A clean *fixed-iteration* strength A/B needs a high iteration count
+(the regime where the tree search, not a single leaf eval, carries strength), but
+the slow baseline rollout makes powered fixed-iteration runs impractical here; at
+a low budget (30 iters) the baseline leads, as expected. A powered
+deterministic-arena run is the recommended next validation (see `tasks/TODO.md`).
+The feature is **default OFF**, so there is no regression risk to the existing
+agent.
 
 ---
 

--- a/docs/TD_LEARNING.md
+++ b/docs/TD_LEARNING.md
@@ -241,11 +241,16 @@ coverage is thin.
 - **Phase-boundary bootstrap — FIXED (2026-06).** `V(s_{t+1})` now uses the next
   state's phase model (`next_phase` stored per row, derived for legacy rows by
   `trajectory_store.annotate_next_phase`). See `docs/TD_AUDIT.md`.
-- **Only eight weights reach the live agent.** The rich features improve the
-  *conditioning* of those eight projected weights but the agent still evaluates
-  with eight fast features (rich features are too slow for per-rollout use).
-  Consuming the full rich model in play would require a separate, slower leaf
-  evaluator.
+- **Only eight weights reach the *rollout* path.** The 8 projected weights drive
+  the per-rollout-step static evaluation, because the rich features are too slow
+  for per-step use. **Addressed (2026-06) for leaf evaluation:** the optional
+  **rich leaf evaluator** (`mcts/rich_leaf_evaluator.py`, flag
+  `rich_leaf_eval_enabled`) applies the full `rich_phase_weights` at MCTS leaves
+  — called once per simulation, not per rollout step — so `score_margin_vs_leader`,
+  `rank_so_far`, mobility, and territory can finally influence search. A cost-tiered
+  feature subset (`score` default ≈0.8 ms/leaf) keeps it within the leaf budget by
+  dropping the all-player opponent-mobility enumeration. See
+  `docs/RICH_FEATURE_ANALYSIS.md §7`.
 - **Linear value model.** No non-linear interactions (see follow-ups: gradient
   boosting / value network).
 - **Self-play roster bias.** Trajectory quality is bounded by the opponents used

--- a/mcts/mcts_agent.py
+++ b/mcts/mcts_agent.py
@@ -481,6 +481,10 @@ class MCTSAgent:
         sufficiency_threshold_enabled: bool = False,
         loss_avoidance_enabled: bool = False,
         loss_avoidance_threshold: float = -50.0,
+        # --- Rich leaf evaluator (45-feature TD value at MCTS leaves) ---
+        rich_leaf_eval_enabled: bool = False,
+        rich_leaf_weights_path: Optional[str] = None,
+        rich_leaf_feature_subset: str = "score",
         # --- Search Trace (Visualization) ---
         enable_search_trace: bool = False,
         search_trace_sample_rate: int = 10,
@@ -543,6 +547,16 @@ class MCTSAgent:
             loss_avoidance_enabled: Enable loss avoidance — redirect away from catastrophic
                 nodes during selection (Layer 9)
             loss_avoidance_threshold: Reward threshold below which a result is catastrophic (Layer 9)
+            rich_leaf_eval_enabled: Evaluate MCTS leaves with the 45-feature TD-learned
+                linear value model instead of a rollout. LEAF-ONLY — called once per
+                simulation, never per rollout step. Default False (backward compatible).
+            rich_leaf_weights_path: Path to the TD artifact holding ``rich_phase_weights``
+                (defaults to ``training/state/td_evaluator_weights.json``). Falls back to
+                the 8-feature evaluator when the artifact/weights are absent.
+            rich_leaf_feature_subset: Cost tier for leaf feature extraction —
+                ``"score"`` (default, ~0.8 ms/leaf), ``"no_opp_mobility"`` (~7 ms),
+                or ``"full"`` (~15-25 ms/leaf). See
+                ``training.rich_features.LEAF_FEATURE_SUBSETS``.
         """
         self.iterations = iterations
         self.time_limit = time_limit
@@ -620,6 +634,11 @@ class MCTSAgent:
         self.sufficiency_threshold_enabled = bool(sufficiency_threshold_enabled)
         self.loss_avoidance_enabled = bool(loss_avoidance_enabled)
         self.loss_avoidance_threshold = float(loss_avoidance_threshold)
+
+        # Rich leaf evaluator params (45-feature TD value at MCTS leaves)
+        self.rich_leaf_eval_enabled = bool(rich_leaf_eval_enabled)
+        self.rich_leaf_weights_path = rich_leaf_weights_path
+        self.rich_leaf_feature_subset = str(rich_leaf_feature_subset)
         # Effective per-move values (set in select_action)
         self._effective_exploration_constant = float(
             adaptive_exploration_base if adaptive_exploration_enabled else exploration_constant
@@ -670,6 +689,27 @@ class MCTSAgent:
             weights=state_eval_weights,
             phase_weights=state_eval_phase_weights,
         )
+
+        # Rich leaf evaluator: the 45-feature TD value model applied at leaves.
+        # Constructed only when enabled; falls back to the 8-feature evaluator
+        # (shared with state_evaluator) when the TD artifact is unavailable.
+        self.rich_leaf_evaluator: Optional["RichLeafEvaluator"] = None
+        if self.rich_leaf_eval_enabled:
+            from .rich_leaf_evaluator import (
+                DEFAULT_RICH_LEAF_WEIGHTS_PATH,
+                RichLeafEvaluator,
+            )
+
+            weights_path = (
+                self.rich_leaf_weights_path
+                if self.rich_leaf_weights_path is not None
+                else DEFAULT_RICH_LEAF_WEIGHTS_PATH
+            )
+            self.rich_leaf_evaluator = RichLeafEvaluator(
+                weights_path,
+                feature_subset=self.rich_leaf_feature_subset,
+                fallback_evaluator=self.state_evaluator,
+            )
         # RNG for random rollout policy
         self._rng = np.random.RandomState(seed)
         # Persist the user-provided seed so root-parallel workers can derive
@@ -702,6 +742,7 @@ class MCTSAgent:
             "transposition_hits": 0,
             "rollout_rewards": [],
             "leaf_eval_calls": 0,
+            "rich_leaf_eval_calls": 0,
             "progressive_bias_updates": 0,
             "potential_shaping_terms": [],
             "evaluator_errors": 0,
@@ -1534,9 +1575,13 @@ class MCTSAgent:
                 self.stats["transposition_hits"] += 1
                 return cached_result["reward"], []
 
-        # Run learned leaf evaluation or rollout.
+        # Run leaf evaluation or rollout. The rich leaf evaluator and the
+        # learned-model leaf evaluator are both LEAF-ONLY: invoked exactly once
+        # per simulation, here at the leaf node — never per rollout step.
         rollout_actions: List[int] = []
-        if self.leaf_evaluation_enabled and self.learned_evaluator is not None:
+        if self.rich_leaf_eval_enabled and self.rich_leaf_evaluator is not None:
+            reward = self._evaluate_rich_leaf(node.board, node.player)
+        elif self.leaf_evaluation_enabled and self.learned_evaluator is not None:
             reward = self._evaluate_leaf(node.board, node.player)
         else:
             reward, rollout_actions = self._rollout(node.board, node.player)
@@ -1547,6 +1592,26 @@ class MCTSAgent:
 
         self.stats["rollout_rewards"].append(reward)
         return reward, rollout_actions
+
+    def _evaluate_rich_leaf(self, board: Board, player: Player) -> float:
+        """Evaluate a leaf with the 45-feature TD-learned linear value model.
+
+        LEAF-ONLY: called once per simulation (in place of the rollout), so the
+        richer feature extraction never runs per rollout step. The value is
+        computed from the **root player's** perspective for consistent
+        backpropagation, matching the rollout/learned-leaf reward semantics, and
+        is scaled by ``_eval_reward_scale`` to sit on the same magnitude as the
+        static-evaluation reward path.
+        """
+        reward_player = self._root_player if self._root_player is not None else player
+        try:
+            value = self.rich_leaf_evaluator.evaluate(board, reward_player)
+            self.stats["rich_leaf_eval_calls"] += 1
+            return float(value) * self._eval_reward_scale
+        except Exception:
+            self.stats["evaluator_errors"] += 1
+            reward, _ = self._rollout(board, player)
+            return reward
 
     def _evaluate_leaf(self, board: Board, player: Player) -> float:
         """Evaluate leaf with learned model-backed win probability.
@@ -2127,6 +2192,7 @@ class MCTSAgent:
             "transposition_hits": 0,
             "rollout_rewards": [],
             "leaf_eval_calls": 0,
+            "rich_leaf_eval_calls": 0,
             "progressive_bias_updates": 0,
             "potential_shaping_terms": [],
             "evaluator_errors": 0,

--- a/mcts/parallel.py
+++ b/mcts/parallel.py
@@ -93,6 +93,10 @@ def _extract_agent_config(agent) -> dict:
         "sufficiency_threshold_enabled": agent.sufficiency_threshold_enabled,
         "loss_avoidance_enabled": agent.loss_avoidance_enabled,
         "loss_avoidance_threshold": agent.loss_avoidance_threshold,
+        # Rich leaf evaluator (45-feature TD value at MCTS leaves)
+        "rich_leaf_eval_enabled": agent.rich_leaf_eval_enabled,
+        "rich_leaf_weights_path": agent.rich_leaf_weights_path,
+        "rich_leaf_feature_subset": agent.rich_leaf_feature_subset,
     }
 
 

--- a/mcts/rich_leaf_evaluator.py
+++ b/mcts/rich_leaf_evaluator.py
@@ -1,0 +1,184 @@
+"""Rich leaf evaluator — the 45-feature TD value model at MCTS leaves.
+
+The live agent's :class:`~mcts.state_evaluator.BlokusStateEvaluator` consumes
+only the **8** SE features projected out of the TD model, discarding the 37 rich
+features (and with them the single most predictive signals —
+``score_margin_vs_leader`` and ``rank_so_far``; see
+``docs/RICH_FEATURE_ANALYSIS.md``). This module lets the *full* TD-learned linear
+value reach search by evaluating it at MCTS **leaves** — where evaluation is
+called once per simulation, not once per rollout step.
+
+The TD artifact (``training/state/td_evaluator_weights.json``) persists
+``rich_phase_weights``: a per-phase ``{"weights": {name: w}, "bias": b}`` map over
+the 45 :data:`~training.rich_features.RICH_FEATURE_NAMES`. The evaluator selects
+the phase by board occupancy (the same early/mid/late thresholds the rest of the
+stack uses) and returns ``Σ w_i·f_i + bias`` — a value in roughly ``[-1, 1]``.
+
+Cost control (the hard constraint): full 45-feature extraction enumerates legal
+moves for **all four** players (~15-25 ms/leaf), so a *feature subset* selects a
+cost tier (see :data:`~training.rich_features.LEAF_FEATURE_SUBSETS`). The default
+``"score"`` subset drops every legal-move enumeration and the territory BFS,
+costing ~0.8 ms/leaf while keeping the highest-signal features. Excluded features
+are zeroed, so their TD weights simply drop out of the dot product.
+
+Graceful fallback: when the artifact is missing or carries no trained rich
+weights, :meth:`RichLeafEvaluator.evaluate` falls back to the 8-feature
+:class:`BlokusStateEvaluator`, and :attr:`available` is ``False``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Optional
+
+import numpy as np
+
+from engine.board import Board, Player
+from engine.move_generator import get_shared_generator
+
+from .state_evaluator import BlokusStateEvaluator
+
+# Default location of the TD artifact holding ``rich_phase_weights``.
+DEFAULT_RICH_LEAF_WEIGHTS_PATH = "training/state/td_evaluator_weights.json"
+
+_PHASES = ("early", "mid", "late")
+
+
+class RichLeafEvaluator:
+    """Evaluate an MCTS leaf with the 45-feature TD-learned linear value model.
+
+    Args:
+        weights_path: Path to the TD artifact with ``rich_phase_weights``.
+        feature_subset: Cost tier — ``"score"`` (default, cheapest),
+            ``"no_opp_mobility"``, or ``"full"`` (see
+            :data:`training.rich_features.LEAF_FEATURE_SUBSETS`).
+        fallback_evaluator: 8-feature evaluator used when rich weights are
+            unavailable (defaults to a fresh :class:`BlokusStateEvaluator`).
+    """
+
+    def __init__(
+        self,
+        weights_path: Optional[str] = DEFAULT_RICH_LEAF_WEIGHTS_PATH,
+        *,
+        feature_subset: str = "score",
+        fallback_evaluator: Optional[BlokusStateEvaluator] = None,
+    ) -> None:
+        # Imported lazily so the agent module does not hard-depend on the
+        # training package at import time.
+        from training.rich_features import (
+            LEAF_FEATURE_SUBSETS,
+            RICH_FEATURE_NAMES,
+            FeatureCache,
+            extract_leaf_features,
+        )
+
+        if feature_subset not in LEAF_FEATURE_SUBSETS:
+            raise ValueError(
+                f"feature_subset must be one of {sorted(LEAF_FEATURE_SUBSETS)}, "
+                f"got '{feature_subset}'"
+            )
+
+        self.weights_path = weights_path
+        self.feature_subset = feature_subset
+        self._rich_feature_names = RICH_FEATURE_NAMES
+        self._feature_cache_cls = FeatureCache
+        self._extract_leaf_features = extract_leaf_features
+        # Share the engine's move generator so per-leaf FeatureCache construction
+        # is free (a fresh LegalMoveGenerator costs ~1.8 ms).
+        self._move_generator = get_shared_generator()
+        self._fallback = fallback_evaluator or BlokusStateEvaluator()
+
+        # Per-phase (weight_vector, bias). weight_vector is ordered to match
+        # RICH_FEATURE_NAMES so it dots directly with the extracted vector.
+        self._phase_weights: Dict[str, np.ndarray] = {}
+        self._phase_bias: Dict[str, float] = {}
+        self.available: bool = False
+        self.load_error: Optional[str] = None
+        self._load_weights()
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def _load_weights(self) -> None:
+        """Load ``rich_phase_weights`` from the artifact; set ``available``.
+
+        Falls back silently (``available=False``) on any problem — missing file,
+        malformed JSON, missing/untrained weights — recording ``load_error``.
+        """
+        path = self.weights_path
+        if not path or not os.path.exists(path):
+            self.load_error = f"weights file not found: {path}"
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                artifact = json.load(fh)
+        except (OSError, ValueError) as exc:
+            self.load_error = f"failed to read weights: {exc}"
+            return
+
+        rich = artifact.get("rich_phase_weights")
+        if not isinstance(rich, dict):
+            self.load_error = "artifact has no 'rich_phase_weights'"
+            return
+
+        index = {name: i for i, name in enumerate(self._rich_feature_names)}
+        n = len(self._rich_feature_names)
+        loaded_any = False
+        for phase in _PHASES:
+            entry = rich.get(phase)
+            if not isinstance(entry, dict):
+                continue
+            weights_map = entry.get("weights")
+            if not isinstance(weights_map, dict):
+                continue
+            vec = np.zeros(n, dtype=float)
+            for name, w in weights_map.items():
+                idx = index.get(name)
+                if idx is not None:
+                    vec[idx] = float(w)
+            self._phase_weights[phase] = vec
+            self._phase_bias[phase] = float(entry.get("bias", 0.0))
+            # A phase counts as usable when it is flagged trained or carries any
+            # non-zero weight (older artifacts may omit the "trained" flag).
+            if entry.get("trained", True) and (
+                np.any(vec != 0.0) or self._phase_bias[phase] != 0.0
+            ):
+                loaded_any = True
+
+        self.available = loaded_any
+        if not loaded_any:
+            self.load_error = "no trained rich phase weights found"
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate(self, board: Board, player: Player) -> float:
+        """Return the leaf value for *player* from the TD model.
+
+        Phase is selected from board occupancy. When rich weights are
+        unavailable, returns the 8-feature ``BlokusStateEvaluator`` score (also
+        in a sane range) so callers degrade gracefully.
+        """
+        if not self.available:
+            return self._fallback.evaluate(board, player)
+
+        phase = BlokusStateEvaluator.get_phase(board)
+        weights = self._phase_weights.get(phase)
+        if weights is None:
+            return self._fallback.evaluate(board, player)
+
+        cache = self._feature_cache_cls(move_generator=self._move_generator)
+        feats = self._extract_leaf_features(
+            board, player, subset=self.feature_subset, cache=cache
+        )
+        # feats is the full ordered feature dict (zeros outside the subset), so a
+        # plain dot over RICH_FEATURE_NAMES applies the subset exactly.
+        x = np.fromiter(
+            (feats[name] for name in self._rich_feature_names),
+            dtype=float,
+            count=len(self._rich_feature_names),
+        )
+        return float(np.dot(weights, x) + self._phase_bias[phase])

--- a/scripts/ab_rich_leaf.py
+++ b/scripts/ab_rich_leaf.py
@@ -1,0 +1,154 @@
+"""Direct A/B: baseline MCTS vs MCTS + rich leaf evaluator.
+
+Plays full 4-player Blokus games with two baseline agents and two rich-leaf
+agents per game, rotating seat assignment to cancel seat bias. Reports win rate,
+mean score, per-leaf evaluation cost, and iterations/move at a **fixed iteration
+budget** so the strength delta is isolated from the per-leaf time cost (which is
+reported separately so the time-budget tradeoff can be reasoned about).
+
+Usage:
+    python -m scripts.ab_rich_leaf --games 16 --iterations 250 --subset score
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Dict
+
+import numpy as np
+
+from engine.board import Player
+from engine.game import BlokusGame
+from mcts.mcts_agent import MCTSAgent
+
+
+def _make_agent(rich: bool, iterations: int, subset: str, seed: int) -> MCTSAgent:
+    return MCTSAgent(
+        iterations=iterations,
+        seed=seed,
+        use_transposition_table=True,
+        rich_leaf_eval_enabled=rich,
+        rich_leaf_feature_subset=subset,
+    )
+
+
+def run_ab(games: int, iterations: int, subset: str, base_seed: int) -> Dict:
+    players = list(Player)
+    # Seat rotation: 'A' = baseline, 'B' = rich. Two of each per game; rotate.
+    rotations = [
+        ["A", "B", "A", "B"],
+        ["B", "A", "B", "A"],
+        ["A", "B", "B", "A"],
+        ["B", "A", "A", "B"],
+    ]
+
+    wins = {"baseline": 0, "rich": 0}
+    ties = 0
+    scores = {"baseline": [], "rich": []}
+    iter_per_move = {"baseline": [], "rich": []}
+    time_per_iter_ms = {"baseline": [], "rich": []}
+    leaf_calls_total = 0
+
+    for g in range(games):
+        layout = rotations[g % len(rotations)]
+        seed = base_seed + g
+        game = BlokusGame()
+        # Build one agent per seat.
+        agents: Dict[Player, MCTSAgent] = {}
+        role: Dict[Player, str] = {}
+        for i, seat in enumerate(players):
+            is_rich = layout[i] == "B"
+            agents[seat] = _make_agent(is_rich, iterations, subset, seed * 17 + i)
+            role[seat] = "rich" if is_rich else "baseline"
+
+        turns = 0
+        max_turns = 400
+        while not game.is_game_over() and turns < max_turns:
+            p = game.get_current_player()
+            moves = game.get_legal_moves(p)
+            if not moves:
+                game.board._update_current_player()
+                game._check_game_over()
+                turns += 1
+                continue
+            agent = agents[p]
+            mv = agent.select_action(game.board, p, moves)
+            if mv is None:
+                game.board._update_current_player()
+                game._check_game_over()
+                turns += 1
+                continue
+            # Telemetry.
+            iters = agent.stats.get("iterations_run", 0)
+            elapsed = agent.stats.get("time_elapsed", 0.0)
+            if iters > 0:
+                iter_per_move[role[p]].append(iters)
+                time_per_iter_ms[role[p]].append(elapsed / iters * 1000.0)
+            if role[p] == "rich":
+                leaf_calls_total += agent.stats.get("rich_leaf_eval_calls", 0)
+            game.make_move(mv, p)
+            turns += 1
+
+        # Tally result.
+        final_scores = {seat: game.get_score(seat) for seat in players}
+        for seat in players:
+            scores[role[seat]].append(final_scores[seat])
+        winner = game.get_winner()
+        if winner is None:
+            ties += 1
+        else:
+            wins[role[winner]] += 1
+        print(
+            f"[game {g+1}/{games}] layout={''.join(layout)} "
+            f"winner={'tie' if winner is None else role[winner]} "
+            f"scores={{base:{np.mean([final_scores[s] for s in players if role[s]=='baseline']):.0f}, "
+            f"rich:{np.mean([final_scores[s] for s in players if role[s]=='rich']):.0f}}}",
+            flush=True,
+        )
+
+    decisive = wins["baseline"] + wins["rich"]
+    summary = {
+        "games": games,
+        "iterations": iterations,
+        "subset": subset,
+        "wins": wins,
+        "ties": ties,
+        "rich_win_rate_overall": wins["rich"] / games if games else 0.0,
+        "rich_win_rate_decisive": wins["rich"] / decisive if decisive else 0.0,
+        "mean_score_baseline": float(np.mean(scores["baseline"])) if scores["baseline"] else 0.0,
+        "mean_score_rich": float(np.mean(scores["rich"])) if scores["rich"] else 0.0,
+        "mean_iters_per_move_baseline": float(np.mean(iter_per_move["baseline"])) if iter_per_move["baseline"] else 0.0,
+        "mean_iters_per_move_rich": float(np.mean(iter_per_move["rich"])) if iter_per_move["rich"] else 0.0,
+        "mean_ms_per_iter_baseline": float(np.mean(time_per_iter_ms["baseline"])) if time_per_iter_ms["baseline"] else 0.0,
+        "mean_ms_per_iter_rich": float(np.mean(time_per_iter_ms["rich"])) if time_per_iter_ms["rich"] else 0.0,
+        "rich_leaf_calls_total": leaf_calls_total,
+    }
+    return summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--games", type=int, default=16)
+    ap.add_argument("--iterations", type=int, default=250)
+    ap.add_argument("--subset", type=str, default="score",
+                    choices=["score", "no_opp_mobility", "full"])
+    ap.add_argument("--seed", type=int, default=20260626)
+    args = ap.parse_args()
+
+    t0 = time.time()
+    summary = run_ab(args.games, args.iterations, args.subset, args.seed)
+    summary["wall_clock_s"] = round(time.time() - t0, 1)
+
+    print("\n==== A/B SUMMARY (baseline vs rich-leaf, fixed iterations) ====")
+    for k, v in summary.items():
+        print(f"  {k}: {v}")
+    base_ms = summary["mean_ms_per_iter_baseline"]
+    rich_ms = summary["mean_ms_per_iter_rich"]
+    if base_ms > 0:
+        print(f"\n  per-iteration cost ratio rich/baseline: {rich_ms / base_ms:.2f}x")
+        print(f"  implied per-leaf overhead: {rich_ms - base_ms:+.3f} ms/iter")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -129,21 +129,49 @@ based.
 
 ## MEDIUM-TERM (remove the bottleneck)
 
-### Richer leaf evaluator  ← TOP medium-term item — **NOW UN-GATED**
+### Richer leaf evaluator  ← TOP medium-term item — **IMPLEMENTED 2026-06-26**
 - **Priority:** High
-- **Expected Strength Gain:** **High** — the change most likely to convert TD's
-  richer model into stronger play.
-- **Complexity:** High · **Risk:** Medium (new eval path; must stay within MCTS
-  leaf budget, not per-rollout-step)
-- **Dependencies:** comparison harness confirming the 8-feature ceiling —
-  **SATISFIED 2026-06-25** by `exp_e1261b8e0c3b` (TD 25% vs regression 39%, Δμ
-  −10; recalibrated labels did not help). The gate condition is met.
-- **Suggested Timing:** **Next.** Validation shows TD does not beat regression even
-  after label calibration, which points squarely at the 45→8 projection.
-- **Reason:** Only 8 of 45 features reach the agent; the most predictive ones do
-  not. Evaluating the full rich vector at MCTS *leaves* (called far less often than
-  rollout steps) lets `rank_so_far`/mobility/territory influence search. See
-  `docs/RICH_FEATURE_ANALYSIS.md`.
+- **Status:** **DONE (default OFF, opt-in).** `mcts/rich_leaf_evaluator.py`
+  (`RichLeafEvaluator`) applies the full 45-feature `rich_phase_weights` at MCTS
+  leaves; wired into `MCTSAgent._simulation` behind `rich_leaf_eval_enabled`
+  (+ `rich_leaf_weights_path`, `rich_leaf_feature_subset`), flowed through
+  `analytics/tournament/arena_runner.py` and `mcts/parallel.py`. Graceful fallback
+  to the 8-feature evaluator when the TD artifact is missing/untrained. Unit tests:
+  `tests/test_rich_leaf_evaluator.py` (evaluator math, phase selection, leaf-only
+  call count, subset value-identity, graceful fallback). Docs:
+  `docs/RICH_FEATURE_ANALYSIS.md §7`, `docs/TD_LEARNING.md §8`.
+- **LEAF-ONLY (measured):** called **once per simulation** (verified by test:
+  `rich_leaf_eval_calls == iterations_run`), never per rollout step.
+- **Per-leaf cost & budget (measured):** full 45-feature extraction is
+  ~15–27 ms/leaf (the all-player opponent-mobility enumeration dominates), so a
+  cost-tiered **feature subset** is used (`training.rich_features.LEAF_FEATURE_SUBSETS`):
+  `score` (default, 27 feats, **~0.8 ms/leaf**), `no_opp_mobility` (41 feats,
+  ~7 ms), `full` (45, ~15–25 ms). The `score` default keeps the three
+  highest-signal non-SE features (`score_margin_vs_leader`, `rank_so_far`,
+  `score_margin_vs_next_player`) which are *cheap* (square counts only).
+- **Iterations/move impact (measured):** because leaf eval **replaces** the
+  expensive heuristic rollout, it is *cheaper* per iteration at Blokus' high
+  branching — on a 334-legal-move position, baseline rollout cost **273 ms/iter**
+  vs rich-`score` **4.5 ms/iter (~60× faster)**. Under a time budget this yields
+  ~60× more iterations; under a fixed-iteration budget the per-leaf cost is paid
+  with iterations to spare. Reproduce: `scripts/ab_rich_leaf.py`.
+- **Strength A/B (directional, powered run still owed):** harness
+  `scripts/ab_rich_leaf.py` (baseline vs rich-`score`, two of each per game,
+  rotating seats). A clean fixed-iteration comparison needs a *high* iteration
+  count — the only regime where the tree search, not a single leaf eval, drives
+  strength — but the baseline's full heuristic rollout (~273 ms/iter at Blokus'
+  high branching) makes powered runs slow. At a low fixed budget (30 iters) the
+  baseline led (one game 82–70), as expected: a 50-move rollout out-informs a
+  single linear leaf eval when the tree barely expands. The leaf evaluator's
+  advantage is **iteration efficiency** (≈60× cheaper/iter), which only shows
+  under time / deterministic-arena budgets. **Recommended:** a powered
+  deterministic-arena run (`scripts/arena.py`, ≥250 iters, many games) to confirm
+  net strength. Feature is **default OFF**, so there is no regression risk.
+- **Reason:** Only 8 of 45 features reached the agent; the most predictive ones did
+  not. Evaluating the rich vector at MCTS *leaves* lets `rank_so_far`/score-margin
+  /mobility/territory influence search. See `docs/RICH_FEATURE_ANALYSIS.md`.
+- **Follow-ups now unblocked:** TD(λ) eligibility traces and opponent-aware value
+  targets (both previously gated on ">8 features reaching the agent").
 
 ### Add top non-SE signals to the live evaluator (interim)
 - **Priority:** Medium

--- a/tests/test_rich_leaf_evaluator.py
+++ b/tests/test_rich_leaf_evaluator.py
@@ -1,0 +1,285 @@
+"""Tests for the rich leaf evaluator (mcts/rich_leaf_evaluator.py) and the
+leaf-subset feature extraction it relies on (training/rich_features.py)."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from engine.board import Board, Player, Position
+from engine.game import BlokusGame
+from engine.move_generator import get_shared_generator
+from mcts.mcts_agent import MCTSAgent
+from mcts.rich_leaf_evaluator import (
+    DEFAULT_RICH_LEAF_WEIGHTS_PATH,
+    RichLeafEvaluator,
+)
+from mcts.state_evaluator import (
+    BlokusStateEvaluator,
+    PHASE_EARLY_THRESHOLD,
+    PHASE_LATE_THRESHOLD,
+)
+import training.rich_features as rf
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _play_board(plies: int, seed: int = 0) -> Board:
+    """Play *plies* heuristic-ish (deterministic median) moves and return board."""
+    random.seed(seed)
+    np.random.seed(seed)
+    game = BlokusGame()
+    for _ in range(plies):
+        p = game.get_current_player()
+        moves = game.get_legal_moves(p)
+        if not moves:
+            game.board._update_current_player()
+            game._check_game_over()
+            continue
+        game.make_move(moves[len(moves) // 2], p)
+        if game.is_game_over():
+            break
+    return game.board
+
+
+def _occupy(board: Board, fraction: float) -> None:
+    """Fill empty cells with RED until at least *fraction* of the board is full."""
+    target = int(fraction * board.SIZE * board.SIZE)
+    for r in range(board.SIZE):
+        for c in range(board.SIZE):
+            if int(np.count_nonzero(board.grid)) >= target:
+                return
+            if board.grid[r, c] == 0:
+                board.grid[r, c] = Player.RED.value
+
+
+# ---------------------------------------------------------------------------
+# Leaf-subset feature extraction
+# ---------------------------------------------------------------------------
+
+
+def test_leaf_subsets_are_defined_and_nested():
+    subs = rf.LEAF_FEATURE_SUBSETS
+    assert set(subs) == {"full", "no_opp_mobility", "score"}
+    # Nesting: score ⊂ no_opp_mobility ⊂ full.
+    assert subs["score"] <= subs["no_opp_mobility"] <= subs["full"]
+    assert subs["full"] == frozenset(rf.RICH_FEATURE_NAMES)
+    # The cheap "score" subset must exclude every enumeration/BFS feature.
+    assert not (subs["score"] & rf.OPPONENT_MOBILITY_FEATURES)
+    assert not (subs["score"] & rf.FOCAL_MOBILITY_FEATURES)
+    assert not (subs["score"] & rf.TERRITORY_FEATURES)
+    # ...but must keep the highest-signal score/rank features.
+    for name in ("score_margin_vs_leader", "rank_so_far", "score_margin_vs_next_player"):
+        assert name in subs["score"]
+
+
+def test_leaf_features_match_full_for_included_and_zero_for_excluded():
+    board = _play_board(14, seed=1)
+    for player in Player:
+        full = rf.extract_rich_features(board, player)
+        for subset in ("full", "no_opp_mobility", "score"):
+            leaf = rf.extract_leaf_features(board, player, subset=subset)
+            # Always the complete ordered name set.
+            assert set(leaf) == set(rf.RICH_FEATURE_NAMES)
+            include = rf.LEAF_FEATURE_SUBSETS[subset]
+            for name in rf.RICH_FEATURE_NAMES:
+                if name in include:
+                    assert leaf[name] == full[name], (subset, name)
+                else:
+                    assert leaf[name] == 0.0, (subset, name)
+
+
+def test_extract_leaf_features_rejects_unknown_subset():
+    board = Board()
+    try:
+        rf.extract_leaf_features(board, Player.RED, subset="nope")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Evaluator math
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_equals_manual_dot_product():
+    """The evaluator output must equal Σ w_i·f_i + bias for the selected phase."""
+    board = _play_board(12, seed=2)
+    ev = RichLeafEvaluator(DEFAULT_RICH_LEAF_WEIGHTS_PATH, feature_subset="full")
+    assert ev.available
+
+    with open(DEFAULT_RICH_LEAF_WEIGHTS_PATH, "r", encoding="utf-8") as fh:
+        artifact = json.load(fh)
+    rich = artifact["rich_phase_weights"]
+
+    for player in Player:
+        phase = BlokusStateEvaluator.get_phase(board)
+        feats = rf.extract_leaf_features(board, player, subset="full")
+        weights_map = rich[phase]["weights"]
+        bias = rich[phase]["bias"]
+        expected = bias + sum(
+            float(weights_map[name]) * feats[name] for name in rf.RICH_FEATURE_NAMES
+        )
+        got = ev.evaluate(board, player)
+        assert abs(got - expected) < 1e-9, (player, phase, got, expected)
+
+
+def test_score_subset_drops_excluded_weight_terms():
+    """The score subset value must omit excluded features' contributions."""
+    board = _play_board(16, seed=5)
+    ev_full = RichLeafEvaluator(DEFAULT_RICH_LEAF_WEIGHTS_PATH, feature_subset="full")
+    ev_score = RichLeafEvaluator(DEFAULT_RICH_LEAF_WEIGHTS_PATH, feature_subset="score")
+    assert ev_full.available and ev_score.available
+
+    with open(DEFAULT_RICH_LEAF_WEIGHTS_PATH, "r", encoding="utf-8") as fh:
+        rich = json.load(fh)["rich_phase_weights"]
+
+    player = Player.RED
+    phase = BlokusStateEvaluator.get_phase(board)
+    feats = rf.extract_rich_features(board, player)
+    include = rf.LEAF_FEATURE_SUBSETS["score"]
+    weights_map = rich[phase]["weights"]
+    bias = rich[phase]["bias"]
+    expected = bias + sum(
+        float(weights_map[name]) * feats[name]
+        for name in rf.RICH_FEATURE_NAMES
+        if name in include
+    )
+    assert abs(ev_score.evaluate(board, player) - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Phase selection
+# ---------------------------------------------------------------------------
+
+
+def test_phase_selection_uses_occupancy_thresholds():
+    ev = RichLeafEvaluator(DEFAULT_RICH_LEAF_WEIGHTS_PATH, feature_subset="full")
+    assert ev.available
+
+    # Early board (empty).
+    early = Board()
+    assert BlokusStateEvaluator.get_phase(early) == "early"
+
+    # Mid board (between early and late thresholds).
+    mid = Board()
+    _occupy(mid, (PHASE_EARLY_THRESHOLD + PHASE_LATE_THRESHOLD) / 2.0)
+    assert BlokusStateEvaluator.get_phase(mid) == "mid"
+
+    # Late board.
+    late = Board()
+    _occupy(late, PHASE_LATE_THRESHOLD + 0.1)
+    assert BlokusStateEvaluator.get_phase(late) == "late"
+
+    # The evaluator must apply the phase-matching weight vector.
+    for board, phase in ((early, "early"), (mid, "mid"), (late, "late")):
+        feats = rf.extract_leaf_features(board, Player.RED, subset="full")
+        x = np.array([feats[n] for n in rf.RICH_FEATURE_NAMES], dtype=float)
+        expected = float(np.dot(ev._phase_weights[phase], x) + ev._phase_bias[phase])
+        assert abs(ev.evaluate(board, Player.RED) - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Graceful fallback
+# ---------------------------------------------------------------------------
+
+
+def test_missing_artifact_falls_back_to_eight_feature_evaluator():
+    ev = RichLeafEvaluator("definitely/missing/file.json", feature_subset="score")
+    assert ev.available is False
+    assert ev.load_error is not None
+
+    board = _play_board(10, seed=3)
+    fallback = BlokusStateEvaluator()
+    for player in Player:
+        # Fallback returns exactly the 8-feature evaluator score in [0, 1].
+        got = ev.evaluate(board, player)
+        assert got == fallback.evaluate(board, player)
+        assert 0.0 <= got <= 1.0
+
+
+def test_empty_rich_weights_marks_unavailable(tmp_path):
+    artifact = {"rich_phase_weights": {}}
+    path = tmp_path / "empty.json"
+    path.write_text(json.dumps(artifact))
+    ev = RichLeafEvaluator(str(path), feature_subset="score")
+    assert ev.available is False
+
+
+def test_invalid_feature_subset_rejected():
+    try:
+        RichLeafEvaluator(DEFAULT_RICH_LEAF_WEIGHTS_PATH, feature_subset="bogus")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Leaf-only invocation in the agent
+# ---------------------------------------------------------------------------
+
+
+def _midgame_board_and_moves(seed: int = 7):
+    board = _play_board(10, seed=seed)
+    gen = get_shared_generator()
+    moves = gen.get_legal_moves(board, Player.RED)
+    return board, moves
+
+
+def test_agent_calls_rich_leaf_exactly_once_per_simulation():
+    """Rich leaf eval is LEAF-ONLY: at most one call per MCTS iteration."""
+    board, moves = _midgame_board_and_moves()
+    assert len(moves) > 1
+    iters = 150
+    agent = MCTSAgent(
+        iterations=iters,
+        seed=11,
+        use_transposition_table=False,
+        rich_leaf_eval_enabled=True,
+        rich_leaf_feature_subset="score",
+    )
+    assert agent.rich_leaf_evaluator.available
+    move = agent.select_action(board, Player.RED, moves)
+    assert move is not None
+    # One rich-leaf evaluation per iteration — never per rollout step.
+    assert agent.stats["rich_leaf_eval_calls"] == iters
+    assert agent.stats["iterations_run"] == iters
+    assert agent.stats["evaluator_errors"] == 0
+
+
+def test_rich_leaf_eval_does_not_touch_rollout_step_path():
+    """With rich leaf eval on, the per-rollout cutoff/two-ply counters stay zero."""
+    board, moves = _midgame_board_and_moves(seed=4)
+    agent = MCTSAgent(
+        iterations=80,
+        seed=2,
+        use_transposition_table=False,
+        rich_leaf_eval_enabled=True,
+        rich_leaf_feature_subset="score",
+    )
+    agent.select_action(board, Player.RED, moves)
+    # The rollout-step static-eval and two-ply paths must be untouched.
+    assert agent.stats["cutoff_evals"] == 0
+    assert agent.stats["two_ply_evals"] == 0
+
+
+def test_agent_default_is_backward_compatible():
+    """Default agent (rich leaf off) must not construct the evaluator."""
+    agent = MCTSAgent(iterations=20, seed=1, use_transposition_table=False)
+    assert agent.rich_leaf_eval_enabled is False
+    assert agent.rich_leaf_evaluator is None
+    board, moves = _midgame_board_and_moves(seed=1)
+    agent.select_action(board, Player.RED, moves)
+    assert agent.stats["rich_leaf_eval_calls"] == 0
+    # Rollouts ran instead.
+    assert len(agent.stats["rollout_rewards"]) > 0

--- a/training/rich_features.py
+++ b/training/rich_features.py
@@ -316,6 +316,72 @@ def _frontier_to_opponent_distance(board: Board, player: Player, frontier) -> fl
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Leaf-evaluator feature subsets (cost tiers)
+# ---------------------------------------------------------------------------
+#
+# extract_rich_features enumerates legal moves for ALL FOUR players (the
+# opponent-mobility features) which costs ~15-27 ms/leaf — far too slow to call
+# even once per MCTS simulation. The groups below classify features by the
+# expensive computation they require so the leaf evaluator can request only an
+# affordable subset (:func:`extract_leaf_features`).
+
+# Features that require enumerating EVERY player's legal moves (the dominant
+# cost, ~11-22 ms): the three opponent-mobility aggregates plus the score
+# leader's mobility.
+OPPONENT_MOBILITY_FEATURES: frozenset = frozenset({
+    "opponent_mobility_avg",
+    "opponent_mobility_max",
+    "opponent_mobility_min",
+    "leader_mobility_pressure",
+})
+
+# Features that require enumerating the FOCAL player's legal moves (~3-5 ms).
+FOCAL_MOBILITY_FEATURES: frozenset = frozenset({
+    "legal_move_count",
+    "legal_move_count_small_pieces",
+    "legal_move_count_medium_pieces",
+    "legal_move_count_large_pieces",
+    "playable_piece_count",
+    "total_playable_piece_area",
+    "avg_legal_move_area",
+    "max_legal_move_area",
+    "corner_quality_score",
+    "new_corner_generation_potential",
+})
+
+# Features that require the whole-board reachable-region / trapped-region BFS
+# (~0.5-1 ms).
+TERRITORY_FEATURES: frozenset = frozenset({
+    "largest_reachable_region",
+    "trapped_region_count",
+    "trapped_region_area",
+    "frontier_density",
+})
+
+# The cheap remainder (SE-8, score/rank/margin, piece inventory, frontier
+# counts, board-position): no legal-move enumeration and no territory BFS,
+# ~0.3 ms on top of the SE-8 features.
+_ALL_FEATURE_SET: frozenset = frozenset(RICH_FEATURE_NAMES)
+SCORE_LEAF_FEATURES: frozenset = (
+    _ALL_FEATURE_SET
+    - OPPONENT_MOBILITY_FEATURES
+    - FOCAL_MOBILITY_FEATURES
+    - TERRITORY_FEATURES
+)
+
+# Named cost tiers exposed to the agent via ``rich_leaf_feature_subset``.
+#   "full"            — all 45 features (~15-27 ms/leaf); usually too slow.
+#   "no_opp_mobility" — drops only the all-player opponent enumeration
+#                       (~4-6 ms/leaf); keeps focal mobility + territory.
+#   "score"           — cheap, high-signal subset (~0.3 ms/leaf); the default.
+LEAF_FEATURE_SUBSETS: Dict[str, frozenset] = {
+    "full": _ALL_FEATURE_SET,
+    "no_opp_mobility": _ALL_FEATURE_SET - OPPONENT_MOBILITY_FEATURES,
+    "score": SCORE_LEAF_FEATURES,
+}
+
+
 def extract_rich_features(
     board: Board,
     player: Player,
@@ -329,10 +395,66 @@ def extract_rich_features(
     finite float. ``cache`` (optional) shares legal-move enumeration across the
     players evaluated for one board state.
     """
+    return _extract_features_impl(
+        board, player, include=_ALL_FEATURE_SET, cache=cache, evaluator=evaluator
+    )
+
+
+def extract_leaf_features(
+    board: Board,
+    player: Player,
+    *,
+    subset: str = "score",
+    cache: Optional[FeatureCache] = None,
+    evaluator: Optional[BlokusStateEvaluator] = None,
+) -> Dict[str, float]:
+    """Return a *subset* of the rich features for cheap MCTS-leaf evaluation.
+
+    Computes only the features in ``LEAF_FEATURE_SUBSETS[subset]`` (skipping the
+    expensive legal-move enumeration / territory BFS for everything else) and
+    zeroes the rest. The included features carry **identical values** to
+    :func:`extract_rich_features` (same gated implementation), so a TD weight
+    vector trained on the full features can be applied directly — the zeroed
+    terms simply drop out of the dot product.
+
+    Args:
+        subset: One of ``"full"``, ``"no_opp_mobility"``, or ``"score"``.
+    """
+    include = LEAF_FEATURE_SUBSETS.get(subset)
+    if include is None:
+        raise ValueError(
+            f"unknown leaf feature subset '{subset}'; "
+            f"expected one of {sorted(LEAF_FEATURE_SUBSETS)}"
+        )
+    return _extract_features_impl(
+        board, player, include=include, cache=cache, evaluator=evaluator
+    )
+
+
+def _extract_features_impl(
+    board: Board,
+    player: Player,
+    *,
+    include: frozenset,
+    cache: Optional[FeatureCache] = None,
+    evaluator: Optional[BlokusStateEvaluator] = None,
+) -> Dict[str, float]:
+    """Shared extraction core for the full and leaf-subset feature paths.
+
+    Only the blocks whose features intersect ``include`` are computed; the
+    expensive focal-mobility, territory, and opponent-mobility blocks are gated
+    so a cheap subset never pays for them. Features outside ``include`` are
+    emitted as ``0.0``. When ``include`` is the full feature set this is
+    behaviourally identical to the original single-pass extraction.
+    """
     cache = cache or FeatureCache()
     evaluator = evaluator or _shared_evaluator()
     sizes = _piece_sizes()
     total_area = total_piece_area()
+
+    need_focal = bool(include & FOCAL_MOBILITY_FEATURES)
+    need_territory = bool(include & TERRITORY_FEATURES)
+    need_opp_mobility = bool(include & OPPONENT_MOBILITY_FEATURES)
 
     # --- Eight SE features (identical semantics to the live agent) -----------
     feats: Dict[str, float] = dict(evaluator.extract_features(board, player))
@@ -341,61 +463,68 @@ def extract_rich_features(
     remaining_ids = _remaining_piece_ids(pieces_used)
     frontier = board.get_frontier(player)
 
-    # --- Mobility / move-space ----------------------------------------------
-    legal_moves = cache.legal_moves(board, player)
-    n_moves = len(legal_moves)
-    small = medium = large = 0
-    areas: List[int] = []
-    playable_ids = set()
-    for mv in legal_moves:
-        pid = int(getattr(mv, "piece_id"))
-        sz = sizes.get(pid, 0)
-        areas.append(sz)
-        playable_ids.add(pid)
-        if sz <= 2:
-            small += 1
-        elif sz == 3:
-            medium += 1
-        else:
-            large += 1
-    playable_area = sum(sizes.get(pid, 0) for pid in playable_ids)
-    avg_area = (sum(areas) / len(areas)) if areas else 0.0
-    max_area = float(max(areas)) if areas else 0.0
+    # --- Mobility / move-space (gated: focal legal-move enumeration) ---------
+    n_moves = 0
+    playable_ids: set = set()
+    if need_focal:
+        legal_moves = cache.legal_moves(board, player)
+        n_moves = len(legal_moves)
+        small = medium = large = 0
+        areas: List[int] = []
+        for mv in legal_moves:
+            pid = int(getattr(mv, "piece_id"))
+            sz = sizes.get(pid, 0)
+            areas.append(sz)
+            playable_ids.add(pid)
+            if sz <= 2:
+                small += 1
+            elif sz == 3:
+                medium += 1
+            else:
+                large += 1
+        playable_area = sum(sizes.get(pid, 0) for pid in playable_ids)
+        avg_area = (sum(areas) / len(areas)) if areas else 0.0
+        max_area = float(max(areas)) if areas else 0.0
 
-    feats["legal_move_count"] = min(n_moves / _MAX_LEGAL_MOVES, 1.0)
-    feats["legal_move_count_small_pieces"] = min(small / _MAX_LEGAL_MOVES, 1.0)
-    feats["legal_move_count_medium_pieces"] = min(medium / _MAX_LEGAL_MOVES, 1.0)
-    feats["legal_move_count_large_pieces"] = min(large / _MAX_LEGAL_MOVES, 1.0)
-    feats["playable_piece_count"] = len(playable_ids) / total_piece_count()
-    feats["total_playable_piece_area"] = playable_area / max(total_area, 1)
-    feats["avg_legal_move_area"] = avg_area / 5.0
-    feats["max_legal_move_area"] = max_area / 5.0
+        feats["legal_move_count"] = min(n_moves / _MAX_LEGAL_MOVES, 1.0)
+        feats["legal_move_count_small_pieces"] = min(small / _MAX_LEGAL_MOVES, 1.0)
+        feats["legal_move_count_medium_pieces"] = min(medium / _MAX_LEGAL_MOVES, 1.0)
+        feats["legal_move_count_large_pieces"] = min(large / _MAX_LEGAL_MOVES, 1.0)
+        feats["playable_piece_count"] = len(playable_ids) / total_piece_count()
+        feats["total_playable_piece_area"] = playable_area / max(total_area, 1)
+        feats["avg_legal_move_area"] = avg_area / 5.0
+        feats["max_legal_move_area"] = max_area / 5.0
 
-    # --- Corner / frontier ---------------------------------------------------
+    # --- Corner / frontier (cheap counts always; quality gated on focal) -----
     feats["frontier_size"] = min(len(frontier) / _MAX_FRONTIER, 1.0)
     feats["corner_count"] = min(len(frontier) / _MAX_FRONTIER, 1.0)
-    # corner quality: legal placements available per anchor (anchors that lead to
-    # many moves are higher quality).
-    feats["corner_quality_score"] = (
-        min((n_moves / max(len(frontier), 1)) / 20.0, 1.0) if frontier else 0.0
-    )
-    largest_reach, trapped_count, trapped_area = _largest_reachable_region_and_trapped(
-        board, frontier
-    )
-    reachable_norm = min((largest_reach) / _MAX_REACHABLE, 1.0)
-    feats["frontier_density"] = (
-        min(len(frontier) / max(largest_reach, 1), 1.0) if largest_reach else 0.0
-    )
+    if need_focal:
+        # corner quality: legal placements available per anchor (anchors that
+        # lead to many moves are higher quality).
+        feats["corner_quality_score"] = (
+            min((n_moves / max(len(frontier), 1)) / 20.0, 1.0) if frontier else 0.0
+        )
+        # new-corner potential: distinct anchor cells reachable by current legal
+        # moves, proxied by playable-piece diversity × frontier breadth.
+        feats["new_corner_generation_potential"] = min(
+            (len(playable_ids) * len(frontier)) / 200.0, 1.0
+        )
+    if need_territory:
+        largest_reach, trapped_count, trapped_area = (
+            _largest_reachable_region_and_trapped(board, frontier)
+        )
+        feats["frontier_density"] = (
+            min(len(frontier) / max(largest_reach, 1), 1.0) if largest_reach else 0.0
+        )
+        # --- Territory and blocking -----------------------------------------
+        feats["largest_reachable_region"] = min(largest_reach / _MAX_REACHABLE, 1.0)
+        feats["trapped_region_count"] = min(trapped_count / 10.0, 1.0)
+        feats["trapped_region_area"] = min(trapped_area / _BOARD_CELLS, 1.0)
     feats["frontier_to_opponent_distance"] = _frontier_to_opponent_distance(
         board, player, frontier
     )
-    # new-corner potential: distinct anchor cells reachable by current legal moves,
-    # proxied by playable-piece diversity × frontier breadth.
-    feats["new_corner_generation_potential"] = min(
-        (len(playable_ids) * len(frontier)) / 200.0, 1.0
-    )
 
-    # --- Piece inventory -----------------------------------------------------
+    # --- Piece inventory (cheap) --------------------------------------------
     rem_by_size = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
     for pid in remaining_ids:
         sz = sizes.get(pid, 0)
@@ -413,28 +542,26 @@ def extract_rich_features(
     distinct_sizes = sum(1 for v in rem_by_size.values() if v > 0)
     feats["piece_diversity_score"] = distinct_sizes / 5.0
 
-    # --- Territory and blocking ---------------------------------------------
-    feats["largest_reachable_region"] = reachable_norm
-    feats["trapped_region_count"] = min(trapped_count / 10.0, 1.0)
-    feats["trapped_region_area"] = min(trapped_area / _BOARD_CELLS, 1.0)
+    # --- Opponent mobility (gated: all-player legal-move enumeration) --------
+    if need_opp_mobility:
+        opp_mobilities: List[int] = []
+        for opp in _PLAYERS:
+            if opp == player:
+                continue
+            opp_mobilities.append(_mobility_count(cache, board, opp))
+        if opp_mobilities:
+            feats["opponent_mobility_avg"] = min(
+                (sum(opp_mobilities) / len(opp_mobilities)) / _MAX_LEGAL_MOVES, 1.0
+            )
+            feats["opponent_mobility_max"] = min(max(opp_mobilities) / _MAX_LEGAL_MOVES, 1.0)
+            feats["opponent_mobility_min"] = min(min(opp_mobilities) / _MAX_LEGAL_MOVES, 1.0)
+        else:
+            feats["opponent_mobility_avg"] = 0.0
+            feats["opponent_mobility_max"] = 0.0
+            feats["opponent_mobility_min"] = 0.0
 
-    opp_mobilities: List[int] = []
-    for opp in _PLAYERS:
-        if opp == player:
-            continue
-        opp_mobilities.append(_mobility_count(cache, board, opp))
-    if opp_mobilities:
-        feats["opponent_mobility_avg"] = min(
-            (sum(opp_mobilities) / len(opp_mobilities)) / _MAX_LEGAL_MOVES, 1.0
-        )
-        feats["opponent_mobility_max"] = min(max(opp_mobilities) / _MAX_LEGAL_MOVES, 1.0)
-        feats["opponent_mobility_min"] = min(min(opp_mobilities) / _MAX_LEGAL_MOVES, 1.0)
-    else:
-        feats["opponent_mobility_avg"] = 0.0
-        feats["opponent_mobility_max"] = 0.0
-        feats["opponent_mobility_min"] = 0.0
-
-    # opponent corner pressure: total opponent frontier near this player's pieces.
+    # opponent corner pressure: total opponent frontier near this player's
+    # pieces (cheap — frontier sets only, no enumeration).
     opp_frontier_total = 0
     for opp in _PLAYERS:
         if opp == player:
@@ -442,14 +569,14 @@ def extract_rich_features(
         opp_frontier_total += len(board.get_frontier(opp))
     feats["opponent_corner_pressure"] = min(opp_frontier_total / (3.0 * _MAX_FRONTIER), 1.0)
 
-    # leader mobility pressure: mobility of the current score leader (excluding self).
+    # --- Score / race (cheap — square counts only) --------------------------
     scores = _player_scores(board)
-    leader = max((p for p in _PLAYERS if p != player), key=lambda p: scores[p.value])
-    feats["leader_mobility_pressure"] = min(
-        _mobility_count(cache, board, leader) / _MAX_LEGAL_MOVES, 1.0
-    )
-
-    # --- Score / race --------------------------------------------------------
+    if need_opp_mobility:
+        # leader mobility pressure: mobility of the current score leader.
+        leader = max((p for p in _PLAYERS if p != player), key=lambda p: scores[p.value])
+        feats["leader_mobility_pressure"] = min(
+            _mobility_count(cache, board, leader) / _MAX_LEGAL_MOVES, 1.0
+        )
     my_score = scores[player.value]
     others = sorted((scores[p.value] for p in _PLAYERS if p != player), reverse=True)
     leader_score = others[0] if others else 0


### PR DESCRIPTION
The live agent only ever sees the 8 SE features projected out of the TD
model; the 37 rich features — including the single most predictive signals
score_margin_vs_leader and rank_so_far — never reach play, which is why TD
does not beat regression (the 45->8 projection is the ceiling, per
docs/RICH_FEATURE_ANALYSIS.md and docs/TD_AUDIT.md).

This wires the full TD-learned linear value model into search by evaluating
it ONLY at MCTS leaves (once per simulation, never per rollout step):

- mcts/rich_leaf_evaluator.py: RichLeafEvaluator loads rich_phase_weights
  from the TD artifact and scores (board, player) as a phase-selected linear
  dot product over the rich features, with graceful fallback to the 8-feature
  BlokusStateEvaluator when the artifact/weights are absent.
- training/rich_features.py: extract_leaf_features + LEAF_FEATURE_SUBSETS
  cost tiers. Full 45-feature extraction enumerates legal moves for all four
  players (~15-25 ms/leaf) — too slow even leaf-only — so the default "score"
  subset (~0.8 ms/leaf) drops every legal-move enumeration and the territory
  BFS while keeping the highest-signal score/rank/positional features.
  "no_opp_mobility" (~7 ms) and "full" remain selectable. Refactored the
  extraction into a single gated core so subset values are identical to the
  full extraction the model was trained on (pinned by tests).
- mcts/mcts_agent.py: rich_leaf_eval_enabled (default False) +
  rich_leaf_weights_path + rich_leaf_feature_subset, hooked into _simulation
  as a leaf-only call. The per-rollout-step and 8-feature serving paths are
  untouched. Backward compatible.
- mcts/parallel.py + analytics/tournament/arena_runner.py: flow the new flags
  through root-parallel workers and arena/approach configs.

Measured: leaf eval REPLACES the rollout, so it is ~60x cheaper per iteration
at Blokus' high branching (baseline rollout ~273 ms/iter vs rich-score
~4.5 ms/iter on a 334-move position). Leaf-only verified by test
(rich_leaf_eval_calls == iterations_run). A powered fixed-iteration strength
A/B is impractical here (slow baseline rollouts); harness scripts/ab_rich_leaf.py
added, powered deterministic-arena run recommended. Default OFF = no regression
risk.

Tests: tests/test_rich_leaf_evaluator.py (evaluator math, phase selection,
leaf-only call count, subset value-identity, graceful fallback). Docs updated:
FEATURES.md, docs/RICH_FEATURE_ANALYSIS.md (§7), docs/TD_LEARNING.md, tasks/TODO.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0174xusrbX5hp6i4uxiEQPef