### PR TITLE
Fix nightly approach-comparison budget starvation + false regression alarm

### DIFF
--- a/docs/06-history/CHANGELOG_NOTES.md
+++ b/docs/06-history/CHANGELOG_NOTES.md
@@ -43,5 +43,28 @@
 - This pass: numbered `docs/00-08` system, archived stale RL-era/superseded docs,
   status-labeled inventories, risk register, planning, and AI-context protocol.
 
+## Phase 7 — Nightly multi-agent training reliability (Jun 2026)
+- **Approach-comparison budget actually compares all approaches (2026-06-29).**
+  The nightly framework had been silently degenerate: a training report showed
+  three of four approaches getting 0 games every run ("time budget exhausted")
+  while `td_learning` alone ran ~199 min against a 45-min budget. Root cause —
+  the eval deadline was only checked *between* `(arena, seed)` sub-batteries, so
+  the first uninterruptible 100-game battery ate the whole budget and every later
+  approach (including `baseline_mcts`, the one able to lift the champion off the
+  sub-heuristic floor) was skipped.
+- Fix landed on three fronts: **game-granular interruption** (`run_experiment`
+  takes a `deadline` checked before each game), a **fair per-candidate budget
+  split** (each remaining candidate gets an equal share of the time left,
+  recomputed so unused time rolls forward), and a **self-consistent workflow
+  config**. Also fixed a **false-positive regression alarm** — a fixed champion's
+  Elo move is sampling variance, not a skill regression, so it is downgraded from
+  a `regression` warn to an `elo_variance` info.
+- **Short eval gate** (`EVAL_MIN_TOTAL_GAMES = 20`) chosen as the starting point
+  so all four approaches fit one CI run; a backlog item tracks A/B-testing a
+  longer eval with a relaxed promotion gate.
+- **Health-verified (2026-06-29):** a smoke run on a temp state copy evaluated
+  **4/4 approaches** within a tight budget (vs 1/4 before the fix), confirming the
+  fair split no longer starves any approach. 44 training tests pass.
+
 > This file is a high-level summary, not a per-commit changelog. For commit-level
 > history use `git log`; for arena-run-level history see the run registry.

--- a/docs/06-history/DECISION_LOG.md
+++ b/docs/06-history/DECISION_LOG.md
@@ -5,6 +5,35 @@
 
 ---
 
+# Decision: Fair-split eval budget + short eval gate for nightly approach comparison
+Date: 2026-06-29
+Status: Accepted
+Context: The nightly approach-comparison run was silently degenerate — the eval
+deadline was only checked between `(arena, seed)` sub-batteries, so the first
+candidate's uninterruptible 100-game battery (~199 min) consumed the entire
+45-min budget and the other three approaches got 0 games on *every* run. The
+"comparison" only ever evaluated one approach.
+Decision: Enforce the deadline at game granularity (`run_experiment(deadline=…)`),
+split the budget fairly across candidates (equal share of remaining time,
+recomputed each iteration), and start with a **short eval gate**
+(`EVAL_MIN_TOTAL_GAMES = 20`, two seeds) so all four approaches fit one CI run at
+full 500 ms strength.
+Why: A comparison that only ever scores one approach is useless; fairness must be
+structural, not dependent on roster order. Short-but-complete beats
+long-but-truncated for a first healthy baseline.
+Alternatives considered: (a) lower the per-move thinking time to fit more games
+at full roster — deferred to a backlog A/B (longer eval + relaxed promotion gate);
+(b) keep the 40-game gate and raise the budget past the 350-min CI cap — rejected
+(doesn't fit one run).
+Consequences: Promotion is conservative on thin runs (fails safe). A backlog item
+tracks testing the opposite regime.
+Verification: smoke run evaluated 4/4 approaches within a tight budget (vs 1/4
+before); 44 training tests pass.
+Related files: `training/evaluation/head_to_head.py`,
+`training/evaluation/promotion_gate.py`, `analytics/tournament/arena_runner.py`,
+`.github/workflows/nightly-mcts-training.yml`,
+`docs/05-planning/BACKLOG.md`.
+
 # Decision: Pivot from RL environment to MCTS platform
 Date: 2026-03-06
 Status: Accepted


### PR DESCRIPTION
## Summary

The last nightly training report surfaced a structural bug: **3 of 4 approaches got 0 games every run** ("time budget exhausted") while `td_learning` alone ran ~199 min against a 45-min budget. The "approach comparison" had been comparing exactly one approach since the framework landed — and `baseline_mcts` (the candidate able to lift the champion off the sub-heuristic floor) was dead-last and never evaluated.

### Root cause
The eval deadline was only checked *between* `(arena, seed)` sub-batteries, but a single 100-game battery of full MCTS is uninterruptible and ~4× the entire budget. The first candidate in the roster ate everything; everyone after it was skipped.

## Changes

**Correctness (the real fix)**
- **Game-granular interruption** — `run_experiment` takes a `deadline` checked before each game, threaded through `run_arena_inproc`. A long battery now stops *between games* instead of overrunning.
- **Fair per-candidate budget split** — `evaluate_candidates` gives each remaining candidate an equal share of the time left (recomputed each iteration so unused time rolls forward), capped by the global deadline. No candidate can starve the others. Zero-game candidates are recorded skipped-for-budget rather than emitting an unusable empty eval.
- **False regression alarm fixed** — `detect_regression` takes `champion_static`; when no promotion changed the champion within the window, an Elo drop is sampling variance, downgraded from a `regression` warn to an `elo_variance` info. The champion has never left `gen0`, so the reported "dropped 101 beyond noise floor" was a false positive.

**Config / tuning**
- **Short eval gate** — shared `EVAL_MIN_TOTAL_GAMES = 20` / `EVAL_MIN_SEEDS = 2` constants in `head_to_head.py` as the single source of truth for both gate layers (replacing two independent `min_total_games=40` defaults).
- **Workflow made self-consistent** — `--games 10` (= 20 total over 2 seeds = the gate minimum), `--time-budget-minutes 210` (~40 min/candidate, four approaches ~160 min with CI headroom), and `baseline` ordered first so the champion-fix candidate gets the first/largest slice.

**Docs**
- `FEATURES.md`, `CHANGELOG_NOTES.md` (new "Phase 7 — Nightly multi-agent training reliability" milestone), `DECISION_LOG.md`, and a `BACKLOG.md` item to later A/B a longer eval paired with a relaxed promotion gate.

## Health verification

- **Dry-run:** 4/4 candidates created, `baseline` first.
- **Smoke eval** (temp state copy, tight budget): **4/4 approaches evaluated** (vs 1/4 before the fix) — the fair split no longer starves any approach. Uneven game counts confirm the game-granular deadline trimming mid-battery as designed.
- **End-to-end deadline test:** 0 games past-deadline, full games with headroom, partial on a tight cutoff.
- **44 training tests pass** (gate, diagnostics, selfplay, approaches), including new static-champion regression cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDVdaMfQ6i9FKpKVeDc689)_