### PR TITLE
Learned move policy (PUCT prior) + expert-iteration data loop

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -242,5 +242,12 @@ python -m mcts_lab.promote      # candidate vs champion gauntlet + gated promoti
 4. Once eval-weight learning saturates, the highest-leverage next feature is
    a stronger rollout/move-ordering policy learned from MCTS visit counts
    (supervised, cheap), then progressive widening at high branching factors.
+   **Implemented (2026-07):** a learned move policy (`mcts/move_policy.py`)
+   distilled from the MCTS root visit distribution
+   (`training/policy_selfplay.py` → `training/policy_learning.py`) and used as a
+   PUCT prior + rollout/ordering policy (`policy_prior_enabled`), surfaced as the
+   `policy` candidate approach. This turns the pipeline into an expert-iteration
+   loop: search generates the policy target, the policy sharpens the next search.
+   Off by default; default policy == the fixed move heuristic.
 5. Consider migrating Elo to placement-based updates (§3.5) with a one-time
    ratings reset.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ Tests: `python -m pytest tests/ -q` (slow — MCTS tests play real games; use
 - `rollout_policy` (`greedy_sample` recommended), `greedy_sample_size` (12),
   `rollout_cutoff_depth` (cut rollout, static-eval all players), `max_rollout_moves`
 - `state_eval_weights` / `state_eval_phase_weights` (Layer-6 evaluator)
+- `policy_prior_enabled` / `policy_prior_c` / `policy_weights` — learned move
+  policy used as a PUCT prior + rollout/ordering policy (off by default; trained
+  from MCTS visit counts by `training.policy_selfplay` → `training.policy_learning`,
+  surfaced as the `policy` approach). Default/untrained policy == the fixed
+  `move_heuristic`, so enabling it without weights is behaviour-safe.
 - Experimental, off by default: `rave_enabled`/`rave_k`, `nst_enabled`,
   `minimax_backup_alpha`, `progressive_widening_enabled`, opponent modeling
   (`opponent_modeling_enabled`, …), parallelization (`num_workers`, …)

--- a/analytics/tournament/arena_runner.py
+++ b/analytics/tournament/arena_runner.py
@@ -470,6 +470,10 @@ def build_agent(config: AgentConfig, seed: int) -> _ArenaAgentAdapter:
             progressive_history_enabled=bool(params.get("progressive_history_enabled", False)),
             progressive_history_weight=float(params.get("progressive_history_weight", 1.0)),
             heuristic_move_ordering=bool(params.get("heuristic_move_ordering", False)),
+            # Learned move policy (PUCT prior + rollout/ordering)
+            policy_prior_enabled=bool(params.get("policy_prior_enabled", False)),
+            policy_prior_c=float(params.get("policy_prior_c", 1.5)),
+            policy_weights=params.get("policy_weights"),
             # Layer 4: Simulation Strategy
             rollout_policy=str(params.get("rollout_policy", "heuristic")),
             two_ply_top_k=int(params["two_ply_top_k"]) if params.get("two_ply_top_k") is not None else None,

--- a/mcts/mcts_agent.py
+++ b/mcts/mcts_agent.py
@@ -45,10 +45,12 @@ from engine.pieces import PieceGenerator
 
 from .learned_evaluator import LearnedWinProbabilityEvaluator
 from .move_heuristic import (
+    compute_move_features,
     compute_move_heuristic,
     move_action_key,
     rank_moves_by_heuristic,
 )
+from .move_policy import MovePolicy, default_move_policy
 from .opponent_model import OpponentModelManager
 from .search_trace import (
     IterationRecord,
@@ -95,6 +97,9 @@ class MCTSNode:
         self.visits = 0
         self.total_reward = 0.0
         self.prior_bias = 0.0
+        # Learned move-policy prior P(s, a) for PUCT selection (set at expansion
+        # from the parent's MovePolicy; 0.0 when the policy prior is disabled).
+        self.policy_prior = 0.0
         self.untried_moves: List[Move] = []
         self._heuristic_sorted = heuristic_sorted
         # Track the total legal move count (before any widening)
@@ -203,6 +208,7 @@ class MCTSNode:
         minimax_alpha: float = 0.0,
         rave_q: float = 0.0,
         rave_beta: float = 0.0,
+        policy_prior_weight: float = 0.0,
     ) -> float:
         """
         Calculate UCB1 value with optional progressive bias, progressive history, and RAVE.
@@ -243,7 +249,20 @@ class MCTSNode:
 
         bias_term = progressive_bias_weight * (self.prior_bias / (1.0 + self.visits))
         history_term = progressive_history_weight * (history_score / (1.0 + self.visits))
-        return exploitation + exploration + bias_term + history_term
+
+        # PUCT prior term (AlphaZero-style): grows with parent visits so the
+        # learned prior guides exploration among visited children, then washes
+        # out as a child accrues its own statistics.
+        #   U = c_puct * P(s,a) * sqrt(N_parent) / (1 + N_child)
+        puct_term = 0.0
+        if policy_prior_weight > 0.0 and self.parent is not None:
+            puct_term = (
+                policy_prior_weight
+                * self.policy_prior
+                * math.sqrt(max(self.parent.visits, 1))
+                / (1.0 + self.visits)
+            )
+        return exploitation + exploration + bias_term + history_term + puct_term
 
     def select_child(
         self,
@@ -255,6 +274,7 @@ class MCTSNode:
         rave_enabled: bool = False,
         rave_k: float = 1000.0,
         loss_avoidance: bool = False,
+        policy_prior_weight: float = 0.0,
     ) -> 'MCTSNode':
         """
         Select child node using UCB1 + progressive history + minimax + RAVE.
@@ -306,6 +326,7 @@ class MCTSNode:
                 minimax_alpha=minimax_alpha,
                 rave_q=child_rave_q,
                 rave_beta=child_rave_beta,
+                policy_prior_weight=policy_prior_weight,
             )
 
         # Layer 9: Loss avoidance — prefer children not flagged as catastrophic
@@ -448,6 +469,10 @@ class MCTSAgent:
         progressive_history_enabled: bool = False,
         progressive_history_weight: float = 1.0,
         heuristic_move_ordering: bool = False,
+        # --- Learned move policy (PUCT prior + rollout/ordering) ---
+        policy_prior_enabled: bool = False,
+        policy_prior_c: float = 1.5,
+        policy_weights: Optional[Dict[str, Any]] = None,
         # --- Layer 4: Simulation Strategy ---
         rollout_policy: str = "heuristic",
         greedy_sample_size: int = 12,
@@ -582,6 +607,27 @@ class MCTSAgent:
         self.progressive_history_enabled = bool(progressive_history_enabled)
         self.progressive_history_weight = float(progressive_history_weight)
         self.heuristic_move_ordering = bool(heuristic_move_ordering)
+
+        # Learned move policy (PUCT prior + rollout/ordering). Loads a MovePolicy
+        # from the serialised ``policy_weights`` dict; when enabled but no weights
+        # are supplied it falls back to the default policy, whose ranking is
+        # identical to the fixed move heuristic (so enabling it is behaviour-safe).
+        self.policy_prior_enabled = bool(policy_prior_enabled)
+        self.policy_prior_c = float(policy_prior_c)
+        self.move_policy = None
+        if policy_weights is not None:
+            try:
+                self.move_policy = MovePolicy.from_dict(policy_weights)
+            except (ValueError, TypeError, KeyError):
+                self.move_policy = None
+        if self.policy_prior_enabled and self.move_policy is None:
+            self.move_policy = default_move_policy()
+        # Active only when the prior is enabled AND a policy is available.
+        self._policy_prior_active = self.policy_prior_enabled and self.move_policy is not None
+        # Optional per-move policy-target capture (self-play collection). When set,
+        # ``select_action`` records the root children's (move, visits) after search.
+        self._capture_root_moves = False
+        self._last_root_move_visits: Optional[List[Tuple[Move, int]]] = None
 
         # Layer 4 params
         if rollout_policy not in {"heuristic", "random", "two_ply", "greedy_sample"}:
@@ -872,8 +918,9 @@ class MCTSAgent:
             self._trace_prev_best_key = None
             self._trace_exploration_grid = [[0] * 20 for _ in range(20)]
 
-        # Heuristic move ordering: sort untried_moves so best are popped last
-        if self.heuristic_move_ordering or self.progressive_widening_enabled:
+        # Heuristic / policy move ordering: sort untried_moves so best are popped
+        # first (and, under the policy prior, cache root children's PUCT priors).
+        if self.heuristic_move_ordering or self.progressive_widening_enabled or self._policy_prior_active:
             self._sort_untried_moves(root)
 
         # Layer 8: Tree parallelization with virtual loss
@@ -906,6 +953,15 @@ class MCTSAgent:
             for c in root.children if c.move is not None and c.visits > 0
         ]
 
+        # Policy-target capture: record (move, visits) for every expanded root
+        # child so self-play can distil the visit distribution into a move policy.
+        # Off by default (only the policy-selfplay collector sets the flag) so the
+        # hot path is untouched during normal play/evaluation.
+        if self._capture_root_moves:
+            self._last_root_move_visits = [
+                (c.move, int(c.visits)) for c in root.children if c.move is not None
+            ]
+
         # Layer 5: Update NST last-action key for cross-move continuity
         if self.nst_enabled and best_move is not None:
             self._last_root_action_key = move_action_key(best_move)
@@ -917,12 +973,45 @@ class MCTSAgent:
         return best_move
 
     def _sort_untried_moves(self, node: MCTSNode) -> None:
-        """Sort a node's untried moves by heuristic score (ascending — best last)."""
+        """Order a node's untried moves best-last (popped first for expansion).
+
+        When the learned move policy prior is active, order by the policy logit
+        and cache each move's softmax prior ``P(a | s)`` on the node, so that
+        newly expanded children receive their PUCT prior (see
+        :meth:`_update_policy_prior`). Otherwise fall back to the fixed heuristic.
+        """
+        if self._policy_prior_active and self.move_policy is not None:
+            moves = list(node.untried_moves)
+            logits = self.move_policy.logits_for_moves(
+                node.board, node.player, moves, self.move_generator
+            )
+            priors = self.move_policy.priors_from_logits(logits)
+            node._policy_prior_by_move_id = {
+                id(m): float(priors[i]) for i, m in enumerate(moves) if m is not None
+            }
+            # Ascending by logit → best move last so pop() expands it first;
+            # pass moves (logit -inf) sort to the front and are popped last.
+            order = sorted(range(len(moves)), key=lambda i: logits[i])
+            node.untried_moves = [moves[i] for i in order]
+            node._heuristic_sorted = True
+            return
         scored = rank_moves_by_heuristic(
             node.board, node.player, node.untried_moves, self.move_generator,
         )
         node.untried_moves = [m for _, m in scored]
         node._heuristic_sorted = True
+
+    def _update_policy_prior(self, parent: MCTSNode, child: MCTSNode) -> None:
+        """Assign a freshly expanded child its learned PUCT prior ``P(s, a)``.
+
+        Reads the softmax priors cached on the parent by :meth:`_sort_untried_moves`.
+        No-op when the policy prior is inactive or the child is a pass node.
+        """
+        if not self._policy_prior_active or child.move is None:
+            return
+        priors = getattr(parent, "_policy_prior_by_move_id", None)
+        if priors:
+            child.policy_prior = priors.get(id(child.move), 0.0)
 
     def _collect_tree_diagnostics(self, root: MCTSNode) -> None:
         """Walk the tree from root to collect diagnostic metrics.
@@ -1017,6 +1106,7 @@ class MCTSAgent:
         Returns (selected_node, selection_depth, avg_exploitation, avg_exploration).
         """
         pw_bias_w = self.progressive_bias_weight if self.progressive_bias_enabled else 0.0
+        policy_w = self.policy_prior_c if self._policy_prior_active else 0.0
         ph_w = self.progressive_history_weight if self.progressive_history_enabled else 0.0
         hist = self._history_table if self.progressive_history_enabled else None
         mm_alpha = self.minimax_backup_alpha
@@ -1043,7 +1133,7 @@ class MCTSAgent:
                         minimax_alpha=mm_alpha,
                         rave_enabled=rave_on,
                         rave_k=rave_k_val,
-                        loss_avoidance=la,
+                        loss_avoidance=la, policy_prior_weight=policy_w,
                     )
                     if chosen.visits > 0 and node.visits > 0:
                         exploit_sum += chosen.blended_q(mm_alpha)
@@ -1066,7 +1156,7 @@ class MCTSAgent:
                     minimax_alpha=mm_alpha,
                     rave_enabled=rave_on,
                     rave_k=rave_k_val,
-                    loss_avoidance=la,
+                    loss_avoidance=la, policy_prior_weight=policy_w,
                 )
                 if chosen.visits > 0 and node.visits > 0:
                     exploit_sum += chosen.blended_q(mm_alpha)
@@ -1327,11 +1417,12 @@ class MCTSAgent:
                     else:
                         expand = not node.is_fully_expanded() and not node.is_terminal()
                     if expand:
-                        if (self.heuristic_move_ordering or self.progressive_widening_enabled) and not node._heuristic_sorted:
+                        if (self.heuristic_move_ordering or self.progressive_widening_enabled or self._policy_prior_active) and not node._heuristic_sorted:
                             self._sort_untried_moves(node)
                         child = node.expand()
                         if child is not None:
                             self._update_progressive_bias(node, child)
+                            self._update_policy_prior(node, child)
                             node = child
                             expanded = True
 
@@ -1373,6 +1464,7 @@ class MCTSAgent:
         node = root
 
         pw_bias_w = self.progressive_bias_weight if self.progressive_bias_enabled else 0.0
+        policy_w = self.policy_prior_c if self._policy_prior_active else 0.0
         ph_w = self.progressive_history_weight if self.progressive_history_enabled else 0.0
         hist = self._history_table if self.progressive_history_enabled else None
         mm_alpha = self.minimax_backup_alpha
@@ -1395,7 +1487,7 @@ class MCTSAgent:
                         minimax_alpha=mm_alpha,
                         rave_enabled=rave_on,
                         rave_k=rave_k,
-                        loss_avoidance=la,
+                        loss_avoidance=la, policy_prior_weight=policy_w,
                     )
                 else:
                     return node, vl_path
@@ -1412,7 +1504,7 @@ class MCTSAgent:
                     minimax_alpha=mm_alpha,
                     rave_enabled=rave_on,
                     rave_k=rave_k,
-                    loss_avoidance=la,
+                    loss_avoidance=la, policy_prior_weight=policy_w,
                 )
 
         return node, vl_path
@@ -1452,12 +1544,13 @@ class MCTSAgent:
         if expand:
             parent = node
             # Sort child moves on first expansion if not done yet
-            if (self.heuristic_move_ordering or self.progressive_widening_enabled) and not node._heuristic_sorted:
+            if (self.heuristic_move_ordering or self.progressive_widening_enabled or self._policy_prior_active) and not node._heuristic_sorted:
                 self._sort_untried_moves(node)
             node = node.expand()
             if node is None:
                 return
             self._update_progressive_bias(parent, node)
+            self._update_policy_prior(parent, node)
 
             # Track explored cells for heatmap
             if trace and self._trace_exploration_grid is not None and node.move is not None:
@@ -1519,6 +1612,7 @@ class MCTSAgent:
             Selected node
         """
         pw_bias_w = self.progressive_bias_weight if self.progressive_bias_enabled else 0.0
+        policy_w = self.policy_prior_c if self._policy_prior_active else 0.0
         ph_w = self.progressive_history_weight if self.progressive_history_enabled else 0.0
         hist = self._history_table if self.progressive_history_enabled else None
         mm_alpha = self.minimax_backup_alpha
@@ -1541,7 +1635,7 @@ class MCTSAgent:
                         minimax_alpha=mm_alpha,
                         rave_enabled=rave_on,
                         rave_k=rave_k,
-                        loss_avoidance=la,
+                        loss_avoidance=la, policy_prior_weight=policy_w,
                     )
                 else:
                     return node
@@ -1557,7 +1651,7 @@ class MCTSAgent:
                     minimax_alpha=mm_alpha,
                     rave_enabled=rave_on,
                     rave_k=rave_k,
-                    loss_avoidance=la,
+                    loss_avoidance=la, policy_prior_weight=policy_w,
                 )
 
         return node
@@ -2032,8 +2126,12 @@ class MCTSAgent:
             candidates = legal_moves
         best_move = candidates[0]
         best_score = -float("inf")
+        use_policy = self._policy_prior_active and self.move_policy is not None
         for m in candidates:
-            s = compute_move_heuristic(board, player, m, self.move_generator)
+            if use_policy:
+                s = self.move_policy.score_move(board, player, m, self.move_generator)
+            else:
+                s = compute_move_heuristic(board, player, m, self.move_generator)
             if s > best_score:
                 best_score = s
                 best_move = m
@@ -2197,6 +2295,10 @@ class MCTSAgent:
                 "progressive_history_enabled": self.progressive_history_enabled,
                 "progressive_history_weight": self.progressive_history_weight,
                 "heuristic_move_ordering": self.heuristic_move_ordering,
+                # Learned move policy (PUCT prior)
+                "policy_prior_enabled": self.policy_prior_enabled,
+                "policy_prior_c": self.policy_prior_c,
+                "policy_prior_active": self._policy_prior_active,
                 # Layer 4
                 "rollout_policy": self.rollout_policy,
                 "two_ply_top_k": self.two_ply_top_k,

--- a/mcts/move_heuristic.py
+++ b/mcts/move_heuristic.py
@@ -58,20 +58,25 @@ def _get_piece_positions(move: Move, move_generator: LegalMoveGenerator) -> List
     return positions
 
 
-def compute_move_heuristic(
+# Ordered names of the move-level features returned by ``compute_move_features``.
+# The learned move policy (``mcts/move_policy.py``) consumes this exact vector, so
+# the order here is the canonical feature order for that model — do not reorder
+# without bumping the policy artifact's feature-set version.
+MOVE_FEATURE_NAMES = ("piece_size", "corners", "center", "blocking")
+
+
+def compute_move_features(
     board: Board,
     player: Player,
     move: Move,
     move_generator: LegalMoveGenerator,
-    *,
-    w_piece_size: float = 1.0,
-    w_corners: float = 2.0,
-    w_center: float = 0.5,
-    w_blocking: float = 1.0,
-) -> float:
-    """Score a single move using domain-specific Blokus features.
+) -> Tuple[float, float, float, float]:
+    """Compute the four normalised move-level features for a single move.
 
-    Returns a raw (un-normalised) heuristic score.  Higher is better.
+    Returns ``(h_size, h_corners, h_center, h_blocking)``, each roughly in
+    ``[0, 1]``. This is the single source of truth shared by the fixed-weight
+    :func:`compute_move_heuristic` and the learned :class:`mcts.move_policy.MovePolicy`
+    — both score a move as a (possibly weighted) combination of these features.
     """
     sizes = _get_piece_sizes()
     piece_size = sizes.get(move.piece_id, 3)
@@ -124,6 +129,29 @@ def compute_move_heuristic(
                     h_blocking += 0.25  # Each adjacency contributes a bit
     h_blocking = min(h_blocking, 1.0)
 
+    return (float(h_size), float(h_corners), float(h_center), float(h_blocking))
+
+
+def compute_move_heuristic(
+    board: Board,
+    player: Player,
+    move: Move,
+    move_generator: LegalMoveGenerator,
+    *,
+    w_piece_size: float = 1.0,
+    w_corners: float = 2.0,
+    w_center: float = 0.5,
+    w_blocking: float = 1.0,
+) -> float:
+    """Score a single move using domain-specific Blokus features.
+
+    Returns a raw (un-normalised) heuristic score.  Higher is better. This is the
+    fixed-weight combination of :func:`compute_move_features`; the learned policy
+    replaces the fixed weights with trained ones.
+    """
+    h_size, h_corners, h_center, h_blocking = compute_move_features(
+        board, player, move, move_generator
+    )
     raw = (
         w_piece_size * h_size
         + w_corners * h_corners

--- a/mcts/move_policy.py
+++ b/mcts/move_policy.py
@@ -1,0 +1,281 @@
+"""Learned move policy — a compact prior over legal moves for PUCT-guided MCTS.
+
+Motivation
+----------
+The canonical MCTS agent scores moves with a *fixed*-weight domain heuristic
+(:func:`mcts.move_heuristic.compute_move_heuristic`, weights ``[1, 2, 0.5, 1]``)
+in two hot places: the ``greedy_sample`` rollout policy and heuristic move
+ordering. There is no *learned* signal shaping the tree search itself — which is
+exactly why deeper search stopped converting into strength (see ``AUDIT_REPORT.md``
+§6.4: "the highest-leverage next feature is a stronger rollout/move-ordering policy
+learned from MCTS visit counts").
+
+This module learns that policy. It is a compact log-linear (softmax) model over
+the same four cheap move features plus a per-piece bias::
+
+    logit(move) = w · phi(move) + piece_bias[piece_id]
+    P(move)     = softmax(logit / temperature)   over the legal moves at a state
+
+Trained by distilling the MCTS **root visit distribution** collected during
+self-play (``training/policy_selfplay.py``) — the search's own improved policy is
+the supervised target (AlphaZero / Expert-Iteration style). The learned ``P`` is
+fed back into the agent as:
+
+* the **PUCT prior** ``P(s, a)`` in tree selection, and
+* the rollout / move-ordering score (replacing the fixed heuristic).
+
+The model is deliberately tiny (4 weights + 21 piece biases): cheap enough to run
+per-node in the search, and it degrades gracefully — an untrained default
+reproduces the existing fixed heuristic exactly, so enabling the prior without
+trained weights never changes behaviour.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from engine.board import Board, Player
+from engine.move_generator import LegalMoveGenerator, Move
+from mcts.move_heuristic import MOVE_FEATURE_NAMES, compute_move_features
+
+# Artifact / feature-set version. Bump if MOVE_FEATURE_NAMES changes.
+POLICY_FEATURE_SET_VERSION = "move_policy_v1"
+
+NUM_MOVE_FEATURES = len(MOVE_FEATURE_NAMES)  # 4
+
+# Fixed weights that reproduce compute_move_heuristic's raw score exactly, so the
+# default (untrained) policy ranks moves identically to the current heuristic.
+DEFAULT_FEATURE_WEIGHTS: Tuple[float, ...] = (1.0, 2.0, 0.5, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MovePolicy:
+    """Log-linear softmax policy over legal moves.
+
+    ``feature_weights`` weights the four :func:`compute_move_features` values;
+    ``piece_bias`` is a per-``piece_id`` additive logit (captures "which piece is
+    good to play now", the knowledge the progressive-history table approximates).
+    ``temperature`` sharpens (<1) or flattens (>1) the softmax used for priors.
+    """
+
+    feature_weights: np.ndarray
+    piece_bias: Dict[int, float] = field(default_factory=dict)
+    temperature: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.feature_weights = np.asarray(self.feature_weights, dtype=float).reshape(-1)
+        if self.feature_weights.shape[0] != NUM_MOVE_FEATURES:
+            raise ValueError(
+                f"feature_weights must have length {NUM_MOVE_FEATURES}, "
+                f"got {self.feature_weights.shape[0]}"
+            )
+        self.piece_bias = {int(k): float(v) for k, v in dict(self.piece_bias).items()}
+        self.temperature = float(self.temperature) if self.temperature > 1e-6 else 1.0
+
+    # -- scoring -----------------------------------------------------------
+
+    def logit_from_features(self, feats: Sequence[float], piece_id: int) -> float:
+        """Raw (pre-softmax) score for one move given its precomputed features."""
+        return float(np.dot(self.feature_weights, feats)) + self.piece_bias.get(int(piece_id), 0.0)
+
+    def score_move(
+        self, board: Board, player: Player, move: Move, move_generator: LegalMoveGenerator
+    ) -> float:
+        """Logit for a single move (higher = better). Monotone rollout/ordering score."""
+        feats = compute_move_features(board, player, move, move_generator)
+        return self.logit_from_features(feats, move.piece_id)
+
+    def logits_for_moves(
+        self,
+        board: Board,
+        player: Player,
+        moves: Sequence[Move],
+        move_generator: LegalMoveGenerator,
+    ) -> np.ndarray:
+        """Vector of logits for a list of moves (``None`` / pass moves score ``-inf``)."""
+        out = np.empty(len(moves), dtype=float)
+        for i, m in enumerate(moves):
+            if m is None:
+                out[i] = -math.inf
+                continue
+            out[i] = self.score_move(board, player, m, move_generator)
+        return out
+
+    def priors_from_logits(self, logits: np.ndarray) -> np.ndarray:
+        """Softmax(logits / temperature), robust to ``-inf`` (pass) and overflow."""
+        z = np.asarray(logits, dtype=float) / self.temperature
+        finite = np.isfinite(z)
+        if not finite.any():
+            # Degenerate (all-pass): uniform over the moves.
+            return np.full(z.shape[0], 1.0 / max(z.shape[0], 1))
+        m = z[finite].max()
+        exp = np.where(finite, np.exp(z - m), 0.0)
+        total = exp.sum()
+        if total <= 0:
+            return np.full(z.shape[0], 1.0 / max(z.shape[0], 1))
+        return exp / total
+
+    def priors(
+        self,
+        board: Board,
+        player: Player,
+        moves: Sequence[Move],
+        move_generator: LegalMoveGenerator,
+    ) -> np.ndarray:
+        """Prior probability distribution ``P(a | s)`` over the given legal moves."""
+        return self.priors_from_logits(self.logits_for_moves(board, player, moves, move_generator))
+
+    # -- serialization -----------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "feature_set_version": POLICY_FEATURE_SET_VERSION,
+            "feature_names": list(MOVE_FEATURE_NAMES),
+            "feature_weights": [float(w) for w in self.feature_weights],
+            "piece_bias": {str(k): float(v) for k, v in self.piece_bias.items()},
+            "temperature": float(self.temperature),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MovePolicy":
+        weights = data.get("feature_weights")
+        if weights is None:
+            raise ValueError("policy dict missing 'feature_weights'")
+        piece_bias = data.get("piece_bias") or {}
+        return cls(
+            feature_weights=np.asarray(weights, dtype=float),
+            piece_bias={int(k): float(v) for k, v in piece_bias.items()},
+            temperature=float(data.get("temperature", 1.0)),
+        )
+
+
+def default_move_policy(temperature: float = 1.0) -> MovePolicy:
+    """Untrained policy whose ranking is identical to the fixed move heuristic."""
+    return MovePolicy(
+        feature_weights=np.array(DEFAULT_FEATURE_WEIGHTS, dtype=float),
+        piece_bias={},
+        temperature=temperature,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Training (visit-count distillation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PolicySample:
+    """One training example: a decision point with its search-visit target.
+
+    ``features`` is ``(n_moves, 4)``; ``piece_ids`` is ``(n_moves,)``;
+    ``target`` is a probability distribution ``(n_moves,)`` (visit counts
+    normalised) — the MCTS-improved policy at this state.
+    """
+
+    features: np.ndarray
+    piece_ids: np.ndarray
+    target: np.ndarray
+
+
+@dataclass
+class PolicyTrainConfig:
+    learning_rate: float = 0.20
+    epochs: int = 40
+    l2: float = 1e-4
+    temperature: float = 1.0
+    seed: int = 12345
+    # Piece ids present in Blokus (1..21). Fixed so the bias vector is stable.
+    piece_ids: Tuple[int, ...] = tuple(range(1, 22))
+
+
+@dataclass
+class PolicyTrainResult:
+    policy: MovePolicy
+    loss: float
+    loss_history: List[float]
+    top1_agreement: float
+    n_samples: int
+
+
+def _softmax(z: np.ndarray) -> np.ndarray:
+    m = z.max()
+    e = np.exp(z - m)
+    return e / e.sum()
+
+
+def train_move_policy(
+    samples: List[PolicySample], config: Optional[PolicyTrainConfig] = None
+) -> PolicyTrainResult:
+    """Fit a :class:`MovePolicy` by distilling visit-count targets (softmax CE).
+
+    Minimises per-decision cross-entropy between the model's softmax over the
+    legal moves and the (normalised) MCTS visit distribution, via full-batch
+    gradient descent with L2 regularisation. Pure / deterministic (no I/O).
+    """
+    cfg = config or PolicyTrainConfig()
+    piece_index = {int(p): i for i, p in enumerate(cfg.piece_ids)}
+    n_pieces = len(cfg.piece_ids)
+
+    # Seed feature weights at the fixed-heuristic prior; biases at zero.
+    w = np.array(DEFAULT_FEATURE_WEIGHTS, dtype=float)
+    b = np.zeros(n_pieces, dtype=float)
+
+    usable = [s for s in samples if s.features.shape[0] >= 2 and np.isfinite(s.target).all()]
+    loss_history: List[float] = []
+
+    for _epoch in range(cfg.epochs):
+        gw = np.zeros_like(w)
+        gb = np.zeros_like(b)
+        epoch_loss = 0.0
+        for s in usable:
+            feats = s.features  # (n,4)
+            pids = s.piece_ids.astype(int)  # (n,)
+            t = s.target  # (n,)
+            bias_vec = np.array([b[piece_index[p]] if p in piece_index else 0.0 for p in pids])
+            z = (feats @ w + bias_vec)  # (n,)
+            q = _softmax(z)
+            # Cross-entropy loss (target is a distribution).
+            epoch_loss += float(-(t * np.log(np.clip(q, 1e-12, 1.0))).sum())
+            # dL/dz = q - t
+            dz = q - t  # (n,)
+            gw += feats.T @ dz
+            for j, p in enumerate(pids):
+                if p in piece_index:
+                    gb[piece_index[p]] += dz[j]
+        n = max(len(usable), 1)
+        gw = gw / n + cfg.l2 * w
+        gb = gb / n + cfg.l2 * b
+        w -= cfg.learning_rate * gw
+        b -= cfg.learning_rate * gb
+        loss_history.append(epoch_loss / n)
+
+    piece_bias = {int(cfg.piece_ids[i]): float(b[i]) for i in range(n_pieces) if abs(b[i]) > 1e-9}
+    policy = MovePolicy(feature_weights=w, piece_bias=piece_bias, temperature=cfg.temperature)
+
+    # Diagnostic: how often the model's argmax matches the visit argmax.
+    agree = 0
+    for s in usable:
+        bias_vec = np.array(
+            [piece_bias.get(int(p), 0.0) for p in s.piece_ids.astype(int)]
+        )
+        z = s.features @ w + bias_vec
+        if int(np.argmax(z)) == int(np.argmax(s.target)):
+            agree += 1
+    top1 = agree / max(len(usable), 1)
+
+    return PolicyTrainResult(
+        policy=policy,
+        loss=loss_history[-1] if loss_history else 0.0,
+        loss_history=loss_history,
+        top1_agreement=top1,
+        n_samples=len(usable),
+    )

--- a/mcts/parallel.py
+++ b/mcts/parallel.py
@@ -58,6 +58,11 @@ def _extract_agent_config(agent) -> dict:
         "progressive_history_enabled": agent.progressive_history_enabled,
         "progressive_history_weight": agent.progressive_history_weight,
         "heuristic_move_ordering": agent.heuristic_move_ordering,
+        # Learned move policy (PUCT prior + rollout/ordering): serialise so each
+        # root-parallel worker rebuilds the same policy instead of dropping it.
+        "policy_prior_enabled": agent.policy_prior_enabled,
+        "policy_prior_c": agent.policy_prior_c,
+        "policy_weights": agent.move_policy.to_dict() if agent.move_policy is not None else None,
         # Layer 4
         "rollout_policy": agent.rollout_policy,
         "two_ply_top_k": agent.two_ply_top_k,

--- a/mcts_lab/self_play.py
+++ b/mcts_lab/self_play.py
@@ -24,6 +24,9 @@ def main(argv=None) -> int:
     ap.add_argument("--seed", type=int, default=None, help="base RNG seed (default: random)")
     ap.add_argument("--thinking-ms", type=int, default=None,
                     help="override MCTS thinking budget (smaller = faster, noisier data)")
+    ap.add_argument("--collect-policy-games", type=int, default=0,
+                    help="also collect this many games of MCTS visit-count policy targets "
+                         "into data/policy_targets.csv (feeds the 'policy' approach)")
     ap.add_argument("--verbose", action="store_true")
     args = ap.parse_args(argv)
 
@@ -53,6 +56,28 @@ def main(argv=None) -> int:
 
     state_store.save_latest(paths, state)
     print(f"\nsnapshot corpus: {total_rows} rows (data/champion_snapshots.csv)")
+
+    if args.collect_policy_games > 0:
+        import copy
+        from training.policy_selfplay import collect_policy_targets
+
+        champ = copy.deepcopy(state["champion_params"])
+        champ["name"] = "champion"
+        champ2 = copy.deepcopy(champ)
+        champ2["name"] = "champion2"
+        roster = [champ, {"name": "heuristic", "type": "heuristic"},
+                  champ2, {"name": "random", "type": "random"}]
+        if args.thinking_ms is not None:
+            for a in roster:
+                if a.get("type", "mcts") == "mcts":
+                    a["thinking_time_ms"] = int(args.thinking_ms)
+        rows = collect_policy_targets(
+            roster, run_id=f"selfplay_{base_seed}", num_games=args.collect_policy_games,
+            seed=base_seed, verbose=args.verbose,
+        )
+        print(f"policy targets: +{rows} rows (data/policy_targets.csv)")
+        print("next: python -m training.policy_learning")
+
     print("next: python -m mcts_lab.train")
     return 0
 

--- a/tests/test_move_policy.py
+++ b/tests/test_move_policy.py
@@ -1,0 +1,199 @@
+"""Tests for the learned move policy (model, training, MCTS integration, wiring)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from engine.board import Board, Player
+from engine.move_generator import get_shared_generator
+from mcts.mcts_agent import MCTSAgent
+from mcts.move_heuristic import (
+    MOVE_FEATURE_NAMES,
+    compute_move_features,
+    compute_move_heuristic,
+)
+from mcts.move_policy import (
+    NUM_MOVE_FEATURES,
+    MovePolicy,
+    PolicySample,
+    PolicyTrainConfig,
+    default_move_policy,
+    train_move_policy,
+)
+
+
+def _opening_moves(n=40):
+    b = Board()
+    gen = get_shared_generator()
+    moves = gen.get_legal_moves(b, Player.RED)
+    return b, gen, moves[:n]
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_feature_vector_shape():
+    b, gen, moves = _opening_moves(5)
+    feats = compute_move_features(b, Player.RED, moves[0], gen)
+    assert len(feats) == NUM_MOVE_FEATURES == len(MOVE_FEATURE_NAMES)
+
+
+def test_default_policy_matches_heuristic_ranking():
+    """The untrained default policy's logit equals the fixed heuristic score."""
+    b, gen, moves = _opening_moves(40)
+    pol = default_move_policy()
+    for m in moves:
+        h = compute_move_heuristic(b, Player.RED, m, gen)
+        p = pol.score_move(b, Player.RED, m, gen)
+        assert p == pytest.approx(h, abs=1e-9)
+
+
+def test_priors_are_a_distribution():
+    b, gen, moves = _opening_moves()
+    pol = default_move_policy()
+    pr = pol.priors(b, Player.RED, moves, gen)
+    assert pr.shape[0] == len(moves)
+    assert float(pr.sum()) == pytest.approx(1.0, abs=1e-9)
+    assert (pr >= 0).all()
+
+
+def test_priors_handle_pass_moves():
+    """A ``None`` (pass) move gets ~zero prior and never NaNs the softmax."""
+    b, gen, moves = _opening_moves(10)
+    pol = default_move_policy()
+    mixed = list(moves) + [None]
+    pr = pol.priors(b, Player.RED, mixed, gen)
+    assert float(pr.sum()) == pytest.approx(1.0, abs=1e-9)
+    assert pr[-1] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_serialization_round_trip():
+    pol = MovePolicy(feature_weights=np.array([0.3, 1.1, -0.2, 0.7]),
+                     piece_bias={5: 0.4, 12: -0.9}, temperature=0.8)
+    back = MovePolicy.from_dict(pol.to_dict())
+    assert np.allclose(back.feature_weights, pol.feature_weights)
+    assert back.piece_bias == pol.piece_bias
+    assert back.temperature == pytest.approx(0.8)
+
+
+def test_bad_feature_weight_length_rejected():
+    with pytest.raises(ValueError):
+        MovePolicy(feature_weights=np.array([1.0, 2.0]))
+
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_samples(n_decisions=300, moves_per=6, seed=0):
+    """Targets favour the 'corners' feature (index 1): the visit mass concentrates
+    on the highest-corner move, so training should raise that weight."""
+    rng = np.random.default_rng(seed)
+    samples = []
+    for _ in range(n_decisions):
+        feats = rng.random((moves_per, NUM_MOVE_FEATURES))
+        pids = rng.integers(1, 22, size=moves_per)
+        # Visit target strongly proportional to corners feature.
+        logits = 6.0 * feats[:, 1]
+        t = np.exp(logits - logits.max())
+        t = t / t.sum()
+        samples.append(PolicySample(features=feats, piece_ids=pids, target=t))
+    return samples
+
+
+def test_training_reduces_loss_and_learns_signal():
+    samples = _synthetic_samples()
+    cfg = PolicyTrainConfig(epochs=60, learning_rate=0.5)
+    result = train_move_policy(samples, cfg)
+    assert result.n_samples == len(samples)
+    # Loss decreased over training.
+    assert result.loss_history[-1] < result.loss_history[0]
+    # The corners weight (index 1) is the dominant learned direction.
+    w = result.policy.feature_weights
+    assert int(np.argmax(w)) == 1
+    # Model recovers the argmax move most of the time.
+    assert result.top1_agreement > 0.75
+
+
+def test_training_handles_empty_and_degenerate():
+    # No samples -> returns default-seeded policy, zero loss, no crash.
+    result = train_move_policy([], PolicyTrainConfig(epochs=3))
+    assert result.n_samples == 0
+    assert result.policy.feature_weights.shape[0] == NUM_MOVE_FEATURES
+
+
+# ---------------------------------------------------------------------------
+# MCTS integration
+# ---------------------------------------------------------------------------
+
+
+def test_agent_runs_with_policy_prior_enabled():
+    b, gen, moves = _opening_moves(0)
+    lm = gen.get_legal_moves(b, Player.RED)
+    keys = {(m.piece_id, m.orientation, m.anchor_row, m.anchor_col) for m in lm}
+    agent = MCTSAgent(iterations=80, seed=1, rollout_policy="greedy_sample",
+                      rollout_cutoff_depth=6, heuristic_move_ordering=True,
+                      policy_prior_enabled=True)
+    assert agent._policy_prior_active is True
+    mv = agent.select_action(b, Player.RED, lm)
+    assert (mv.piece_id, mv.orientation, mv.anchor_row, mv.anchor_col) in keys
+
+
+def test_policy_prior_disabled_by_default():
+    agent = MCTSAgent(iterations=10, seed=1)
+    assert agent._policy_prior_active is False
+    assert agent.move_policy is None
+
+
+def test_agent_deterministic_with_policy():
+    def run():
+        b = Board()
+        gen = get_shared_generator()
+        lm = gen.get_legal_moves(b, Player.RED)
+        agent = MCTSAgent(iterations=80, seed=7, rollout_policy="greedy_sample",
+                          rollout_cutoff_depth=6, heuristic_move_ordering=True,
+                          policy_prior_enabled=True)
+        return agent.select_action(b, Player.RED, lm)
+
+    a, b = run(), run()
+    assert (a.piece_id, a.orientation, a.anchor_row, a.anchor_col) == \
+           (b.piece_id, b.orientation, b.anchor_row, b.anchor_col)
+
+
+def test_capture_hook_records_visit_distribution():
+    b = Board()
+    gen = get_shared_generator()
+    lm = gen.get_legal_moves(b, Player.RED)
+    agent = MCTSAgent(iterations=100, seed=3, rollout_policy="greedy_sample",
+                      rollout_cutoff_depth=6, heuristic_move_ordering=True)
+    agent._capture_root_moves = True
+    agent.select_action(b, Player.RED, lm)
+    assert agent._last_root_move_visits is not None
+    total = sum(v for _, v in agent._last_root_move_visits)
+    assert total == 100  # every iteration expands/visits a root child
+
+
+def test_arena_build_agent_round_trips_policy_params():
+    from analytics.tournament.arena_runner import AgentConfig, build_agent
+
+    pol = default_move_policy().to_dict()
+    cfg = AgentConfig.from_dict({
+        "name": "policy", "type": "mcts", "thinking_time_ms": None,
+        "params": {
+            "iterations": 40, "rollout_policy": "greedy_sample",
+            "rollout_cutoff_depth": 6, "heuristic_move_ordering": True,
+            "policy_prior_enabled": True, "policy_prior_c": 2.0,
+            "policy_weights": pol,
+        },
+    })
+    adapter = build_agent(cfg, seed=1)
+    agent = adapter.agent
+    assert isinstance(agent, MCTSAgent)
+    assert agent._policy_prior_active is True
+    assert agent.policy_prior_c == pytest.approx(2.0)
+    assert np.allclose(agent.move_policy.feature_weights,
+                       default_move_policy().feature_weights)

--- a/training/README.md
+++ b/training/README.md
@@ -28,6 +28,32 @@ python -m training.nightly_run --approaches all --games 100 --time-budget-minute
 The legacy self-play generation loop is still available when `--approaches` is
 omitted (`python -m training.nightly_run --hours 5 --games-per-arena 12`).
 
+### Learned move policy (expert iteration)
+
+The `policy` approach learns a compact log-linear move policy by distilling the
+MCTS **root visit distribution** collected during self-play, then searches with it
+as a PUCT prior *and* the rollout / move-ordering policy — the first candidate
+pathway that improves *how the tree is searched*, not just the leaf evaluator (see
+`AUDIT_REPORT.md` §6.4). Like TD, it trains from an already-collected corpus, so
+collect targets first:
+
+```bash
+# 1. Collect MCTS visit-count targets into data/policy_targets.csv
+python -m training.policy_selfplay --num-games 40 --thinking-time-ms 50
+#    (or piggyback on a snapshot run: mcts_lab.self_play --collect-policy-games 40)
+
+# 2. Distil them into training/state/policy_weights.json
+python -m training.policy_learning
+
+# 3. The `policy` approach then builds a candidate that searches with the prior
+python -m training.nightly_run --approaches policy,baseline --games 40
+```
+
+The learned policy is stored on the champion config as
+`params.policy_prior_enabled` + `params.policy_weights` and flows through the arena
+like any other parameter. An untrained/default policy reproduces the fixed move
+heuristic exactly, so enabling the prior without weights never changes behaviour.
+
 ## Architecture (separation of concerns)
 
 ```
@@ -39,6 +65,7 @@ training/
     heuristic_tuning.py#   regression re-fit of Layer-6 weights
     mcts_param_sweep.py#   search-parameter variant
     hybrid_td_mcts.py  #   strong search + TD-learned evaluator
+    policy_prior.py    #   learned move policy (PUCT prior + rollout/ordering)
   evaluation/          # measurement + promotion
     benchmark_pool.py  #   fixed, versioned opponent roster + fixed seeds
     head_to_head.py    #   pooled 4-agent battery vs the pool (per candidate)

--- a/training/approaches/__init__.py
+++ b/training/approaches/__init__.py
@@ -30,6 +30,7 @@ def _register() -> None:
         heuristic_tuning,
         hybrid_td_mcts,
         mcts_param_sweep,
+        policy_prior,
         td_learning,
     )
 
@@ -39,6 +40,7 @@ def _register() -> None:
         mcts_param_sweep.NAME: mcts_param_sweep.make,
         td_learning.NAME: td_learning.make,
         hybrid_td_mcts.NAME: hybrid_td_mcts.make,
+        policy_prior.NAME: policy_prior.make,
     })
 
 

--- a/training/approaches/policy_prior.py
+++ b/training/approaches/policy_prior.py
@@ -1,0 +1,117 @@
+"""Policy-prior approach — learn a move policy and search with it (PUCT).
+
+Distils the MCTS visit-count corpus collected by :mod:`training.policy_selfplay`
+into a compact move policy (:mod:`training.policy_learning`) and builds a champion
+clone that searches with that policy as its PUCT prior and rollout/ordering policy
+(``policy_prior_enabled=True`` + ``policy_weights``). This is the first candidate
+pathway that changes *how the search itself is guided by learned knowledge* rather
+than only re-fitting the leaf evaluator — the expert-iteration lever from
+``AUDIT_REPORT.md`` §6.4.
+
+Like the TD approach, every failure mode returns a specific reason (no corpus, too
+few decisions, non-finite loss) instead of silently skipping.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from pathlib import Path
+from typing import Optional
+
+from training.approaches.base import Approach, ApproachContext, Candidate
+
+NAME = "policy"
+
+
+class PolicyPriorApproach:
+    name = NAME
+
+    def __init__(self, min_samples: int = 200) -> None:
+        self.min_samples = min_samples
+
+    def generate(self, ctx: ApproachContext) -> Candidate:
+        from training import policy_learning as pl
+        from training.approaches.baseline_mcts import strong_baseline_params
+        from training.policy_selfplay import DEFAULT_POLICY_CSV
+
+        champ = ctx.champion_params()
+        if not champ:
+            return Candidate(
+                name=self.name, approach="policy_prior", created=False,
+                reason="policy: no champion_params in state (cold start incomplete)",
+            )
+
+        out_path = pl.DEFAULT_OUTPUT
+        traj_path = Path(DEFAULT_POLICY_CSV)
+
+        # Train fresh if we have a corpus; else reuse an existing artifact.
+        trained_ok, reason, policy_dict, metrics = self._train(pl, traj_path, out_path)
+        if not trained_ok and policy_dict is None:
+            return Candidate(name=self.name, approach="policy_prior", created=False,
+                             reason=reason, metrics=metrics)
+
+        # Build on the corrected strong-search base, then enable the learned prior.
+        cfg = strong_baseline_params(champ)
+        cfg.setdefault("params", {})
+        cfg["params"]["policy_prior_enabled"] = True
+        cfg["params"]["policy_weights"] = policy_dict
+        cfg["name"] = self.name
+        return Candidate(
+            name=self.name,
+            approach="policy_prior",
+            created=True,
+            reason=(
+                f"policy: distilled {metrics.get('n_samples', '?')} decisions "
+                f"(loss={metrics.get('loss')}, top1={metrics.get('top1_agreement')})"
+                if trained_ok else f"policy: reused existing artifact at {out_path}"
+            ),
+            agent_config=cfg,
+            metrics={**metrics, "learning_method": "visit_count_distillation"},
+        )
+
+    def _train(self, pl, traj_path: Path, out_path: Path):
+        """Train the policy -> (ok, reason, policy_dict_or_None, metrics)."""
+        import json
+
+        if not traj_path.exists():
+            # No corpus: try to reuse a previously written artifact.
+            if out_path.exists():
+                try:
+                    art = json.loads(out_path.read_text(encoding="utf-8"))
+                    return False, "policy: reused artifact", art.get("policy"), {}
+                except (json.JSONDecodeError, OSError):
+                    pass
+            return (False,
+                    f"policy: no target CSV at {traj_path}; run "
+                    "`python -m training.policy_selfplay` to collect visit targets first",
+                    None, {})
+
+        from mcts.move_policy import PolicyTrainConfig
+
+        config = PolicyTrainConfig()
+        result, reason, _samples = pl.train_from_file(
+            traj_path, config, min_samples=self.min_samples
+        )
+        if result is None:
+            # Fall back to an existing artifact if training could not proceed.
+            if out_path.exists():
+                try:
+                    art = json.loads(out_path.read_text(encoding="utf-8"))
+                    return False, reason, art.get("policy"), {}
+                except (json.JSONDecodeError, OSError):
+                    pass
+            return False, reason, None, {}
+
+        artifact = pl.build_artifact(result, config)
+        pl.write_artifact(artifact, out_path)
+        metrics = {
+            "n_samples": result.n_samples,
+            "loss": round(float(result.loss), 6),
+            "top1_agreement": round(float(result.top1_agreement), 4),
+        }
+        return True, reason, artifact["policy"], metrics
+
+
+def make(min_samples: int = 200) -> Approach:
+    return PolicyPriorApproach(min_samples=min_samples)

--- a/training/policy_learning.py
+++ b/training/policy_learning.py
@@ -1,0 +1,140 @@
+"""Train the learned move policy from collected MCTS visit-count targets.
+
+Reads ``data/policy_targets.csv`` (produced by :mod:`training.policy_selfplay`),
+distils the per-decision visit distributions into a compact log-linear move
+policy (:func:`mcts.move_policy.train_move_policy`), and writes an artifact to
+``training/state/policy_weights.json``. The artifact's ``policy`` block is exactly
+what the agent consumes as ``policy_weights`` (PUCT prior + rollout/ordering).
+
+CLI::
+
+    python -m training.policy_learning \
+        --input data/policy_targets.csv \
+        --output training/state/policy_weights.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from mcts.move_heuristic import MOVE_FEATURE_NAMES
+from mcts.move_policy import (
+    POLICY_FEATURE_SET_VERSION,
+    PolicySample,
+    PolicyTrainConfig,
+    PolicyTrainResult,
+    train_move_policy,
+)
+from training import REPO_ROOT
+from training.policy_selfplay import DEFAULT_POLICY_CSV, load_policy_samples
+
+DEFAULT_OUTPUT = REPO_ROOT / "training" / "state" / "policy_weights.json"
+
+# Minimum grouped decisions required before we trust a fitted policy.
+MIN_SAMPLES = 200
+
+
+def build_artifact(result: PolicyTrainResult, config: PolicyTrainConfig) -> Dict[str, Any]:
+    """Assemble the serialisable policy-weights artifact."""
+    return {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "learning_method": "visit_count_distillation",
+        "feature_set_version": POLICY_FEATURE_SET_VERSION,
+        "feature_names": list(MOVE_FEATURE_NAMES),
+        "n_samples": result.n_samples,
+        "policy": result.policy.to_dict(),
+        "training_metrics": {
+            "loss": float(result.loss),
+            "top1_agreement": float(result.top1_agreement),
+            "n_samples": result.n_samples,
+            "epochs": config.epochs,
+            "learning_rate": config.learning_rate,
+            "l2": config.l2,
+        },
+    }
+
+
+def write_artifact(artifact: Dict[str, Any], output: Path | str = DEFAULT_OUTPUT) -> Path:
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        json.dump(artifact, handle, indent=2)
+    return output
+
+
+def train_from_file(
+    input_path: Path | str,
+    config: Optional[PolicyTrainConfig] = None,
+    *,
+    min_samples: int = MIN_SAMPLES,
+) -> Tuple[Optional[PolicyTrainResult], str, List[PolicySample]]:
+    """Load targets and train. Returns ``(result_or_None, reason, samples)``.
+
+    ``result`` is ``None`` (with an explanatory ``reason``) when the corpus is
+    missing / too small / produced a non-finite loss.
+    """
+    samples = load_policy_samples(input_path)
+    if not samples:
+        return None, f"policy: no usable rows in {input_path}", samples
+    if len(samples) < min_samples:
+        return (None,
+                f"policy: only {len(samples)} decisions (need {min_samples}); "
+                "collect more via `python -m training.policy_selfplay`",
+                samples)
+    result = train_move_policy(samples, config or PolicyTrainConfig())
+    if not math.isfinite(result.loss):
+        return None, f"policy: non-finite training loss ({result.loss})", samples
+    return result, "policy: trained", samples
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description="Distil MCTS visit counts into a move policy.")
+    p.add_argument("--input", default=str(DEFAULT_POLICY_CSV))
+    p.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    p.add_argument("--epochs", type=int, default=40)
+    p.add_argument("--learning-rate", type=float, default=0.20)
+    p.add_argument("--l2", type=float, default=1e-4)
+    p.add_argument("--temperature", type=float, default=1.0)
+    p.add_argument("--min-samples", type=int, default=MIN_SAMPLES)
+    p.add_argument("--dry-run", action="store_true",
+                   help="Train and print metrics but do not write the artifact.")
+    args = p.parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"[policy_learning] Input not found: {input_path}")
+        print("[policy_learning] Collect targets first via training.policy_selfplay.")
+        return 1
+
+    config = PolicyTrainConfig(
+        learning_rate=args.learning_rate, epochs=args.epochs,
+        l2=args.l2, temperature=args.temperature,
+    )
+    result, reason, samples = train_from_file(
+        input_path, config, min_samples=int(args.min_samples)
+    )
+    if result is None:
+        print(f"[policy_learning] {reason}")
+        return 1
+
+    artifact = build_artifact(result, config)
+    print(f"[policy_learning] samples={result.n_samples} loss={result.loss:.5f} "
+          f"top1_agreement={result.top1_agreement:.3f}")
+    print(f"[policy_learning] feature_weights={artifact['policy']['feature_weights']}")
+
+    if args.dry_run:
+        print("[policy_learning] --dry-run: not writing artifact.")
+        return 0
+
+    out = write_artifact(artifact, args.output)
+    print(f"[policy_learning] wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/policy_selfplay.py
+++ b/training/policy_selfplay.py
@@ -1,0 +1,311 @@
+"""Self-play collection of MCTS visit-count targets for the learned move policy.
+
+Plays full Blokus games with arena agents (reusing
+:func:`analytics.tournament.arena_runner.build_agent`) and, at every decision
+made by an MCTS agent, records the **root visit distribution** over that
+decision's legal moves. Each candidate move contributes one CSV row carrying its
+four move-features (:func:`mcts.move_heuristic.compute_move_features`), its
+``piece_id`` and its MCTS visit count; rows sharing a ``decision_id`` form one
+training example. The visit distribution is the search's own improved policy, and
+distilling it (:mod:`training.policy_learning`) yields a move policy that guides
+the *next* generation's search — the core of the expert-iteration loop.
+
+Written to ``data/policy_targets.csv``. Kept deliberately separate from the arena
+per-move machinery (like :mod:`training.td_selfplay`) so it never touches the
+snapshot / promotion flow. Determinism mirrors the arena: fixed ``seed`` ⇒ same
+games and same recorded visit counts.
+"""
+
+from __future__ import annotations
+
+import csv
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+from analytics.tournament.arena_runner import AgentConfig, build_agent
+from engine.board import Player
+from engine.game import BlokusGame
+from engine.move_generator import get_shared_generator
+from mcts.mcts_agent import MCTSAgent
+from mcts.move_heuristic import MOVE_FEATURE_NAMES, compute_move_features
+from mcts.move_policy import PolicySample
+from training import REPO_ROOT
+from training.rich_features import board_occupancy, get_phase
+
+DEFAULT_POLICY_CSV = REPO_ROOT / "data" / "policy_targets.csv"
+
+POLICY_CSV_COLUMNS: List[str] = [
+    "run_id", "game_id", "seed", "ply", "player_id", "phase", "board_occupancy",
+    "decision_id", "piece_id",
+    "feat_piece_size", "feat_corners", "feat_center", "feat_blocking",
+    "visits", "n_moves",
+]
+
+_PLAYERS: List[Player] = list(Player)
+
+
+# ---------------------------------------------------------------------------
+# CSV store
+# ---------------------------------------------------------------------------
+
+
+def append_policy_rows(rows: List[Dict[str, Any]], path: Path | str = DEFAULT_POLICY_CSV) -> int:
+    """Append policy-target rows to the CSV (writing the header if new). Returns count."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not path.exists() or path.stat().st_size == 0
+    with path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=POLICY_CSV_COLUMNS)
+        if write_header:
+            writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+    return len(rows)
+
+
+def load_policy_samples(path: Path | str = DEFAULT_POLICY_CSV) -> List[PolicySample]:
+    """Load and group CSV rows into per-decision :class:`PolicySample` targets.
+
+    Decisions with fewer than two candidate moves or zero total visits carry no
+    learnable ranking signal and are skipped.
+    """
+    path = Path(path)
+    if not path.exists():
+        return []
+    groups: Dict[str, Dict[str, List[float]]] = {}
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            key = row["decision_id"]
+            g = groups.setdefault(key, {"feats": [], "pids": [], "visits": []})
+            g["feats"].append([
+                float(row["feat_piece_size"]), float(row["feat_corners"]),
+                float(row["feat_center"]), float(row["feat_blocking"]),
+            ])
+            g["pids"].append(int(row["piece_id"]))
+            g["visits"].append(float(row["visits"]))
+
+    samples: List[PolicySample] = []
+    for g in groups.values():
+        visits = np.asarray(g["visits"], dtype=float)
+        total = visits.sum()
+        if len(visits) < 2 or total <= 0:
+            continue
+        samples.append(PolicySample(
+            features=np.asarray(g["feats"], dtype=float),
+            piece_ids=np.asarray(g["pids"], dtype=int),
+            target=visits / total,
+        ))
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# Single-game collection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CollectStats:
+    decisions: int = 0
+    rows: int = 0
+
+
+def _record_decision(
+    underlying: MCTSAgent,
+    board: Any,
+    player: Player,
+    *,
+    run_id: str,
+    game_id: str,
+    seed: int,
+    ply: int,
+    decision_idx: int,
+) -> List[Dict[str, Any]]:
+    """Build CSV rows from an MCTS agent's last root visit distribution."""
+    move_visits = getattr(underlying, "_last_root_move_visits", None)
+    if not move_visits:
+        return []
+    gen = get_shared_generator()
+    phase = get_phase(board)
+    occ = float(board_occupancy(board))
+    decision_id = f"{game_id}_p{player.value}_d{decision_idx}"
+    n_moves = len(move_visits)
+    rows: List[Dict[str, Any]] = []
+    for move, visits in move_visits:
+        f_size, f_corners, f_center, f_blocking = compute_move_features(board, player, move, gen)
+        rows.append({
+            "run_id": run_id, "game_id": game_id, "seed": seed, "ply": ply,
+            "player_id": int(player.value), "phase": phase, "board_occupancy": occ,
+            "decision_id": decision_id, "piece_id": int(move.piece_id),
+            "feat_piece_size": f_size, "feat_corners": f_corners,
+            "feat_center": f_center, "feat_blocking": f_blocking,
+            "visits": int(visits), "n_moves": n_moves,
+        })
+    return rows
+
+
+def play_and_collect(
+    agents: Sequence[Dict[str, Any]],
+    *,
+    run_id: str,
+    game_id: str,
+    seed: int,
+    output_path: Path | str = DEFAULT_POLICY_CSV,
+    max_turns: int = 2500,
+) -> _CollectStats:
+    """Play one game, recording every MCTS seat's root visit distribution."""
+    if len(agents) != 4:
+        raise ValueError("play_and_collect requires exactly 4 agent configs")
+
+    random.seed(seed)
+    np.random.seed(seed)
+
+    adapters: Dict[int, Any] = {}
+    underlying: Dict[int, Optional[MCTSAgent]] = {}
+    for i, cfg in enumerate(agents):
+        adapter = build_agent(AgentConfig.from_dict(cfg), seed=seed * 31 + i + 1)
+        adapters[i + 1] = adapter
+        agent = getattr(adapter, "agent", None)
+        if isinstance(agent, MCTSAgent):
+            agent._capture_root_moves = True  # enable visit-distribution capture
+            # Force single-process search: the root-parallel path returns early
+            # and never records per-child visit counts, so capture requires one
+            # in-process tree (also cleaner / deterministic for a training target).
+            agent.num_workers = 1
+            underlying[i + 1] = agent
+        else:
+            underlying[i + 1] = None
+
+    game = BlokusGame()
+    stats = _CollectStats()
+    decision_idx: Dict[int, int] = {p.value: 0 for p in _PLAYERS}
+    pending_rows: List[Dict[str, Any]] = []
+
+    turn_count = 0
+    while not game.is_game_over() and turn_count < max_turns:
+        current = game.get_current_player()
+        legal_moves = game.get_legal_moves(current)
+        turn_count += 1
+        if not legal_moves:
+            game.board._update_current_player()
+            game._check_game_over()
+            continue
+
+        cur_id = int(current.value)
+        ply = int(game.board.move_count)
+        board_before = game.board.copy()
+        thinking = agents[cur_id - 1].get("thinking_time_ms")
+        move, _stats = adapters[cur_id].choose_move(game.board, current, legal_moves, thinking)
+
+        mcts_agent = underlying[cur_id]
+        if mcts_agent is not None and len(legal_moves) >= 2:
+            rows = _record_decision(
+                mcts_agent, board_before, current,
+                run_id=run_id, game_id=game_id, seed=seed, ply=ply,
+                decision_idx=decision_idx[cur_id],
+            )
+            if rows:
+                pending_rows.extend(rows)
+                stats.decisions += 1
+                decision_idx[cur_id] += 1
+
+        if move is None or not game.make_move(move, current):
+            game.board._update_current_player()
+            game._check_game_over()
+            continue
+
+    if pending_rows:
+        stats.rows = append_policy_rows(pending_rows, output_path)
+    return stats
+
+
+def collect_policy_targets(
+    agents: Sequence[Dict[str, Any]],
+    *,
+    run_id: str,
+    num_games: int,
+    seed: int,
+    output_path: Path | str = DEFAULT_POLICY_CSV,
+    verbose: bool = False,
+) -> int:
+    """Play ``num_games`` games and append policy-target rows. Returns rows written."""
+    total = 0
+    for g in range(num_games):
+        stats = play_and_collect(
+            agents, run_id=run_id, game_id=f"{run_id}_g{g:04d}",
+            seed=seed + g, output_path=output_path,
+        )
+        total += stats.rows
+        if verbose:
+            print(f"[policy_selfplay] game {g+1}/{num_games}: "
+                  f"{stats.decisions} decisions, {stats.rows} rows", flush=True)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _default_agents() -> List[Dict[str, Any]]:
+    """Champion (MCTS) vs a mix of opponents — the champion seat drives collection."""
+    try:
+        import copy as _copy
+
+        from scripts.champion_loop import BASE_CHAMPION_PARAMS
+
+        champ = _copy.deepcopy(BASE_CHAMPION_PARAMS)
+        champ["name"] = "champion"
+        champ2 = _copy.deepcopy(BASE_CHAMPION_PARAMS)
+        champ2["name"] = "champion2"
+        return [
+            champ,
+            {"name": "heuristic", "type": "heuristic"},
+            champ2,
+            {"name": "random", "type": "random"},
+        ]
+    except Exception:
+        return [
+            {"name": "heuristic", "type": "heuristic"},
+            {"name": "random", "type": "random"},
+            {"name": "heuristic2", "type": "heuristic"},
+            {"name": "random2", "type": "random"},
+        ]
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Collect MCTS visit-count policy targets into data/policy_targets.csv."
+    )
+    p.add_argument("--num-games", type=int, default=20)
+    p.add_argument("--seed", type=int, default=2026)
+    p.add_argument("--run-id", default="policycollect")
+    p.add_argument("--output", default=str(DEFAULT_POLICY_CSV))
+    p.add_argument("--thinking-time-ms", type=int, default=None,
+                   help="Override every MCTS agent's thinking budget (small ⇒ fast collection).")
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args(argv)
+
+    agents = _default_agents()
+    if args.thinking_time_ms is not None:
+        for a in agents:
+            if a.get("type", "mcts") == "mcts":
+                a["thinking_time_ms"] = int(args.thinking_time_ms)
+
+    total = collect_policy_targets(
+        agents, run_id=args.run_id, num_games=args.num_games, seed=args.seed,
+        output_path=args.output, verbose=args.verbose,
+    )
+    print(f"[policy_selfplay] wrote {total} rows to {args.output} "
+          f"(feature order: {list(MOVE_FEATURE_NAMES)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/policy_selfplay.py
+++ b/training/policy_selfplay.py
@@ -235,9 +235,13 @@ def collect_policy_targets(
     """Play ``num_games`` games and append policy-target rows. Returns rows written."""
     total = 0
     for g in range(num_games):
+        game_seed = seed + g
+        # Bake the game seed into the id so re-running collection with a different
+        # seed under the same run-id never produces colliding decision_ids (which
+        # load_policy_samples groups on) — that would merge unrelated positions.
         stats = play_and_collect(
-            agents, run_id=run_id, game_id=f"{run_id}_g{g:04d}",
-            seed=seed + g, output_path=output_path,
+            agents, run_id=run_id, game_id=f"{run_id}_s{game_seed}_g{g:04d}",
+            seed=game_seed, output_path=output_path,
         )
         total += stats.rows
         if verbose:
@@ -285,13 +289,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     )
     p.add_argument("--num-games", type=int, default=20)
     p.add_argument("--seed", type=int, default=2026)
-    p.add_argument("--run-id", default="policycollect")
+    p.add_argument("--run-id", default=None,
+                   help="Collection run id (default: a unique timestamped id so "
+                        "separate runs never collide in data/policy_targets.csv).")
     p.add_argument("--output", default=str(DEFAULT_POLICY_CSV))
     p.add_argument("--thinking-time-ms", type=int, default=None,
                    help="Override every MCTS agent's thinking budget (small ⇒ fast collection).")
     p.add_argument("--verbose", action="store_true")
     args = p.parse_args(argv)
 
+    run_id = args.run_id or (
+        "policycollect_" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    )
     agents = _default_agents()
     if args.thinking_time_ms is not None:
         for a in agents:
@@ -299,7 +308,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 a["thinking_time_ms"] = int(args.thinking_time_ms)
 
     total = collect_policy_targets(
-        agents, run_id=args.run_id, num_games=args.num_games, seed=args.seed,
+        agents, run_id=run_id, num_games=args.num_games, seed=args.seed,
         output_path=args.output, verbose=args.verbose,
     )
     print(f"[policy_selfplay] wrote {total} rows to {args.output} "


### PR DESCRIPTION
## Why

The nightly report shows the plateau is **real**, not noise. The champion hasn't changed since **gen 140** (11-generation promotion drought), so the "+0.3 Elo/gen" is a *fixed* agent's rating estimate converging (the monotonic decay 1.9→0.3 is the signature of a settling estimate, not learning). Meanwhile the two candidate approaches both *lose* to the champion (47%, 45% head-to-head).

Root cause: the only learnable component is a **linear evaluator over ~6 hand-crafted features** fed a **static final-score target** — and *nothing shapes the search itself*. Re-fitting that evaluator just wobbles around the same optimum, and deeper search stopped converting into strength. `AUDIT_REPORT.md` §6.4 already named the fix: *"a stronger rollout/move-ordering policy learned from MCTS visit counts."*

## What

Adds that lever and wires up the data loop that feeds it, turning the pipeline into an **expert-iteration** loop: the search generates a policy target (its root visit distribution), the learned policy sharpens the next search.

**Core**
- `mcts/move_policy.py` — compact log-linear softmax move policy over the four existing move features + a per-piece bias; softmax priors; visit-count distillation trainer (pure numpy). The default/untrained policy reproduces the fixed move heuristic **exactly**, so enabling the prior without trained weights never changes behaviour.
- `mcts/move_heuristic.py` — factor out `compute_move_features()` as the single source of truth shared by the fixed heuristic and the learned policy.
- `mcts/mcts_agent.py` — new `policy_prior_enabled` / `policy_prior_c` / `policy_weights` params; PUCT term `U = c·P(s,a)·√N_parent / (1+N_child)` in UCB; policy-guided expansion order + prior caching on nodes; policy-scored `greedy_sample` rollout; opt-in root visit-distribution capture hook. **All gated off by default** — policy-off search is verified byte-identical to before.

**Data loop**
- `training/policy_selfplay.py` — collect MCTS root visit distributions into `data/policy_targets.csv` (forces single-process search so per-child visit counts are captured).
- `training/policy_learning.py` — distil the corpus into `training/state/policy_weights.json`.
- `training/approaches/policy_prior.py` — new `policy` approach (strong-search base + learned prior), registered in the roster; available via `--approaches policy,...` and `all`.
- `mcts_lab/self_play.py` — `--collect-policy-games` grows the corpus in one command.
- `analytics/tournament/arena_runner.py` — round-trips the new params so the policy flows through the arena like any other config.

## How it flows

```
policy_selfplay (visit counts) → policy_learning (distil) → policy_weights.json
        → `policy` approach grafts it onto a champion clone → promotion gate (unchanged)
```

The learned policy lives on the champion config as `params.policy_prior_enabled` + `params.policy_weights`. Promotion still goes through the existing honest gate — this PR does not touch champion selection or the gate.

## Testing

- New `tests/test_move_policy.py`: model math, softmax + pass-move handling, serialization round-trip, visit-count training recovers a planted signal, MCTS integration + determinism, capture hook, arena round-trip.
- Regression suites all green: `test_maxn_backprop`, `test_layer3/5/6`, `test_tactical_positions`, `test_layer8_parallelization`, `test_training_approaches`, `test_training_promotion_gate`, `test_training_selfplay_core`, `test_arena_stats` (133 tests total across the touched areas), plus `python -m mcts_lab.checks`.
- End-to-end smoke: collect → load → distil → build candidate produces a valid `policy` candidate with grafted weights.

## Notes / scope

- Off by default and behaviour-preserving when disabled; the production nightly workflow's default approach list (`baseline,heuristic_tune`) is intentionally **not** changed here (that would alter its budget/runtime). Enable via `--approaches policy,baseline` after collecting a corpus.
- This is the first of the planned increments; follow-ups (search-bootstrapped value targets, richer leaf features, league play, gate throughput) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnuGBNU7hkNswxvZ95VbF1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnuGBNU7hkNswxvZ95VbF1)_