### PR TITLE
Fix P1: run promotion bookkeeping after sequential eval (follow-up to #186)

### DIFF
--- a/tests/test_training_dryrun.py
+++ b/tests/test_training_dryrun.py
@@ -76,6 +76,49 @@ def test_generation_not_advanced_when_no_evaluation_runs(tmp_path, monkeypatch):
     assert "fake: nothing to learn" in (paths.reports_dir / "approach_comparison.md").read_text()
 
 
+def test_sequential_eval_runs_promotion_bookkeeping(tmp_path, monkeypatch):
+    """Regression: with --sequential-eval, the shared bookkeeping (generation increment,
+    Elo/TrueSkill replay, promotion) must run — it must NOT be stranded in the
+    non-sequential branch. On the buggy control flow this test fails because the
+    generation counter never advances in sequential mode even though games were played.
+    """
+    from training.approaches.base import Candidate
+    from training.evaluation.head_to_head import HeadToHeadResult
+
+    paths = _seed(tmp_path)
+    before = json.loads(paths.latest_json.read_text())
+
+    class _MakesCandidate:
+        name = "cand"
+
+        def generate(self, ctx):
+            return Candidate(name="cand", approach="test", created=True,
+                             reason="test: created",
+                             agent_config={"type": "mcts", "thinking_time_ms": 5, "params": {}})
+
+    monkeypatch.setattr(nr.ap_pkg, "build_approaches", lambda names: [_MakesCandidate()])
+
+    # Stand in for the real (slow) SPRT arena: return played games but no winner, so the
+    # promotion branch is skipped and only the *shared* bookkeeping is under test.
+    games = [{"agent_scores": {"champion": 40, "cand": 50, "o1": 30, "o2": 20}},
+             {"agent_scores": {"champion": 45, "cand": 55, "o1": 30, "o2": 20}}]
+    ht = HeadToHeadResult(pool={}, seeds=[1, 2], games_per_arena=2, candidate_evals=[],
+                          all_games=games, run_dirs=[], skipped_for_budget=[])
+    monkeypatch.setattr(nr, "evaluate_candidates_sequential", lambda *a, **k: (ht, {}))
+
+    nr.run_approaches(
+        paths=paths, approaches=["cand"], games_per_arena=2, seeds=[1, 2],
+        time_budget_minutes=5, thinking_time_ms=5, promote_registry=False,
+        dry_run=False, verbose=False, sequential_eval=True,
+    )
+
+    after = json.loads(paths.latest_json.read_text())
+    # The evaluation ran (2 games) -> the shared bookkeeping must have advanced the
+    # generation and recorded the games. On the pre-fix control flow this stays at 5.
+    assert after["generation"] == before["generation"] + 1
+    assert after.get("total_games", 0) == before.get("total_games", 0) + 2
+
+
 def test_resolve_approaches_all_and_csv():
     assert nr._resolve_approaches("all") == list(__import__(
         "training.approaches", fromlist=["DEFAULT_APPROACHES"]).DEFAULT_APPROACHES)

--- a/training/nightly_run.py
+++ b/training/nightly_run.py
@@ -920,94 +920,94 @@ def run_approaches(
     confirmation_record = None
     sprt_results: Dict[str, Any] = {}
 
-    if created and time.monotonic() < deadline and sequential_eval:
-        # Variance-reduced sequential screen (SPRT on the paired champion-vs-candidate
-        # outcome, seat-balanced). Decisive candidates — clearly better OR clearly not —
-        # resolve in few games; only genuinely borderline ones cost many. A candidate is
-        # promotable only if the SPRT accepts H1 *and* it clears the conservative gate on
-        # those same games, so the SPRT evidence doubles as the confirmation battery.
+    if created and time.monotonic() < deadline:
         pool = build_benchmark_pool(state, seeds=seeds)
-        ht, sprt_results = evaluate_candidates_sequential(
-            state, created, pool, paths, seeds=seeds, thinking_time_ms=thinking_time_ms,
-            elo1=sprt_elo1, min_games=sprt_min_games, max_games=sprt_max_games,
-            deadline=deadline, verbose=verbose,
-        )
-        evals_by_name = {e.name: e for e in ht.candidate_evals}
-        gates_by_name = {ce.name: evaluate_gate(ce, GateThresholds())
-                         for ce in ht.candidate_evals}
-        improved = [ce for ce in ht.candidate_evals
-                    if sprt_results.get(ce.name) is not None
-                    and sprt_results[ce.name].is_improvement]
-        sel = select_winner(improved, GateThresholds())
-        gates_by_name.update(sel["gates"])  # authoritative gate for the winner subset
-        winner = sel["winner"]
-        total_eval_games = len(ht.all_games)
-        # Fold the SPRT verdict into each candidate's report reason for visibility.
-        for c in created:
-            sr = sprt_results.get(c.name)
-            if sr is not None:
-                c.reason = f"{c.reason} — {sr.summary_line()}"
-        if winner is not None:
-            sr = sprt_results.get(winner.name)
-            confirmation_record = {
-                "candidate": winner.name, "approach": winner.approach,
-                "method": "sprt_sequential",
-                "screen_games": int(sr.n_games) if sr else 0,
-                "confirm_games": int(sr.n_games) if sr else 0,
-                "confirm_min_games": sprt_min_games,
-                "passed": True,
-                "reason": (sr.summary_line() if sr else ""),
-            }
-    elif created and time.monotonic() < deadline:
-        pool = build_benchmark_pool(state, seeds=seeds)
-        ht = evaluate_candidates(
-            state, created, pool, paths,
-            games_per_arena=games_per_arena, seeds=seeds,
-            thinking_time_ms=thinking_time_ms, deadline=deadline, verbose=verbose,
-        )
-        evals_by_name = {e.name: e for e in ht.candidate_evals}
-        sel = select_winner(ht.candidate_evals, GateThresholds())
-        gates_by_name = sel["gates"]
-        winner = sel["winner"]
-        total_eval_games = len(ht.all_games)
-
-        # Two-stage promotion (audit #4): the screen above identified a leading
-        # candidate over the cheap 20-game gate. Before promoting, re-evaluate ONLY
-        # that candidate over a larger confirmation sample and require it to clear
-        # the gate again at the higher game floor. A lucky short run can no longer
-        # promote on its own; the extra cost is bounded to one candidate and the
-        # remaining wall-clock budget.
-        if two_stage_promotion and winner is not None and time.monotonic() < deadline:
-            wcand0 = next((c for c in created if c.name == winner.name), None)
-            if wcand0 is not None and getattr(wcand0, "agent_config", None):
-                conf_eval, conf_games, _conf_dirs = ht_confirm_winner(
-                    state, winner.name, winner.approach, wcand0.agent_config, pool, paths,
-                    seeds=seeds, thinking_time_ms=thinking_time_ms,
-                    deadline=deadline, verbose=verbose,
-                )
-                conf_gate = evaluate_gate(
-                    conf_eval, GateThresholds(min_total_games=EVAL_CONFIRM_TOTAL_GAMES))
-                # The champion plays every confirmation game too — fold them into the
-                # pooled game set so ratings and counts reflect the full evidence.
-                ht.all_games.extend(conf_games)
-                total_eval_games = len(ht.all_games)
+        if sequential_eval:
+            # Variance-reduced sequential screen (SPRT on the paired champion-vs-candidate
+            # outcome, seat-balanced). Decisive candidates — clearly better OR clearly not —
+            # resolve in few games; only genuinely borderline ones cost many. A candidate is
+            # promotable only if the SPRT accepts H1 *and* it clears the conservative gate on
+            # those same games, so the SPRT evidence doubles as the confirmation battery.
+            ht, sprt_results = evaluate_candidates_sequential(
+                state, created, pool, paths, seeds=seeds, thinking_time_ms=thinking_time_ms,
+                elo1=sprt_elo1, min_games=sprt_min_games, max_games=sprt_max_games,
+                deadline=deadline, verbose=verbose,
+            )
+            evals_by_name = {e.name: e for e in ht.candidate_evals}
+            gates_by_name = {ce.name: evaluate_gate(ce, GateThresholds())
+                             for ce in ht.candidate_evals}
+            improved = [ce for ce in ht.candidate_evals
+                        if sprt_results.get(ce.name) is not None
+                        and sprt_results[ce.name].is_improvement]
+            sel = select_winner(improved, GateThresholds())
+            gates_by_name.update(sel["gates"])  # authoritative gate for the winner subset
+            winner = sel["winner"]
+            total_eval_games = len(ht.all_games)
+            # Fold the SPRT verdict into each candidate's report reason for visibility.
+            for c in created:
+                sr = sprt_results.get(c.name)
+                if sr is not None:
+                    c.reason = f"{c.reason} — {sr.summary_line()}"
+            if winner is not None:
+                sr = sprt_results.get(winner.name)
                 confirmation_record = {
-                    "candidate": winner.name,
-                    "approach": winner.approach,
-                    "screen_games": int(evals_by_name[winner.name].games),
-                    "confirm_games": int(conf_eval.games),
-                    "confirm_min_games": EVAL_CONFIRM_TOTAL_GAMES,
-                    "passed": bool(conf_gate.passed),
-                    "reason": conf_gate.reason,
+                    "candidate": winner.name, "approach": winner.approach,
+                    "method": "sprt_sequential",
+                    "screen_games": int(sr.n_games) if sr else 0,
+                    "confirm_games": int(sr.n_games) if sr else 0,
+                    "confirm_min_games": sprt_min_games,
+                    "passed": True,
+                    "reason": (sr.summary_line() if sr else ""),
                 }
-                if conf_gate.passed:
-                    # Promote on the stronger confirmation evidence.
-                    evals_by_name[winner.name] = conf_eval
-                    gates_by_name[winner.name] = conf_gate
-                    winner = conf_eval
-                else:
-                    # The screen result did not hold up over more games — hold.
-                    winner = None
+        else:
+            ht = evaluate_candidates(
+                state, created, pool, paths,
+                games_per_arena=games_per_arena, seeds=seeds,
+                thinking_time_ms=thinking_time_ms, deadline=deadline, verbose=verbose,
+            )
+            evals_by_name = {e.name: e for e in ht.candidate_evals}
+            sel = select_winner(ht.candidate_evals, GateThresholds())
+            gates_by_name = sel["gates"]
+            winner = sel["winner"]
+            total_eval_games = len(ht.all_games)
+
+            # Two-stage promotion (audit #4): the screen above identified a leading
+            # candidate over the cheap 20-game gate. Before promoting, re-evaluate ONLY
+            # that candidate over a larger confirmation sample and require it to clear
+            # the gate again at the higher game floor. A lucky short run can no longer
+            # promote on its own; the extra cost is bounded to one candidate and the
+            # remaining wall-clock budget.
+            if two_stage_promotion and winner is not None and time.monotonic() < deadline:
+                wcand0 = next((c for c in created if c.name == winner.name), None)
+                if wcand0 is not None and getattr(wcand0, "agent_config", None):
+                    conf_eval, conf_games, _conf_dirs = ht_confirm_winner(
+                        state, winner.name, winner.approach, wcand0.agent_config, pool, paths,
+                        seeds=seeds, thinking_time_ms=thinking_time_ms,
+                        deadline=deadline, verbose=verbose,
+                    )
+                    conf_gate = evaluate_gate(
+                        conf_eval, GateThresholds(min_total_games=EVAL_CONFIRM_TOTAL_GAMES))
+                    # The champion plays every confirmation game too — fold them into the
+                    # pooled game set so ratings and counts reflect the full evidence.
+                    ht.all_games.extend(conf_games)
+                    total_eval_games = len(ht.all_games)
+                    confirmation_record = {
+                        "candidate": winner.name,
+                        "approach": winner.approach,
+                        "screen_games": int(evals_by_name[winner.name].games),
+                        "confirm_games": int(conf_eval.games),
+                        "confirm_min_games": EVAL_CONFIRM_TOTAL_GAMES,
+                        "passed": bool(conf_gate.passed),
+                        "reason": conf_gate.reason,
+                    }
+                    if conf_gate.passed:
+                        # Promote on the stronger confirmation evidence.
+                        evals_by_name[winner.name] = conf_eval
+                        gates_by_name[winner.name] = conf_gate
+                        winner = conf_eval
+                    else:
+                        # The screen result did not hold up over more games — hold.
+                        winner = None
 
         # A real evaluation ran -> advance the durable generation counter now. A
         # skipped/empty cycle must NOT look like a completed generation.


### PR DESCRIPTION
Follow-up to #186 (already merged), fixing a **P1 control-flow bug** in that PR that the Codex review caught after merge.

## The bug

#186 added the `--sequential-eval` path as a separate `if` branch, which turned the existing evaluation block into an `elif`. That stranded the **shared post-evaluation bookkeeping** — generation increment, skipped-candidate reporting, Elo/TrueSkill replay, and the `_promote_winner` call — inside the *non-sequential* `elif`.

Because the nightly workflow now defaults to `--sequential-eval`, the consequence was severe: **an SPRT-accepted winner would never be promoted**, and the played games never updated ratings or the generation counter. The nightly would run, evaluate, find a winner, and then silently drop it.

## The fix

Restructure into an outer `if created and within-deadline:` with an inner `if sequential_eval: … else: …`, so the shared bookkeeping runs after *either* evaluation mode (which is how it worked before the sequential branch was bolted on). No behavior change for the non-sequential path.

## Test

Adds `test_sequential_eval_runs_promotion_bookkeeping`, which drives `run_approaches(..., sequential_eval=True)` with a stubbed eval that returns played games, and asserts the generation counter advances and games are recorded. This **fails on the pre-fix control flow** (generation stays put) and passes on the fix. 56 related training tests pass.

Thanks to the Codex reviewer for catching this — my original unit/mocked tests and dry-run didn't exercise the `run_approaches` promotion path in sequential mode, which is exactly where the bug lived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbM4m2UPXZG5ZEXJ8sbnC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbM4m2UPXZG5ZEXJ8sbnC9)_