### PR TITLE
Agent-strength rescue: master plan, Phase 0 nightly freeze, Phase 1 forensic audit

### DIFF
--- a/.github/workflows/nightly-mcts-training.yml
+++ b/.github/workflows/nightly-mcts-training.yml
@@ -2,17 +2,19 @@ name: nightly-mcts-training
 
 # Durable, resumable Blokus MCTS self-play training.
 #
-# Runs every 6 hours, RESUMES from the committed durable state under training/state/,
-# trains within a wall-clock budget, evaluates + (internally) promotes a candidate,
-# regenerates reports, commits the updated state back to the repo, and ALWAYS emails
-# a summary — on success and on failure. See docs/03-implementation/NIGHTLY_TRAINING.md.
+# RESUMES from the committed durable state under training/state/, trains within a
+# wall-clock budget, evaluates + (internally) promotes a candidate, regenerates
+# reports, commits the updated state back to the repo, and ALWAYS emails a summary —
+# on success and on failure. See docs/03-implementation/NIGHTLY_TRAINING.md.
+#
+# SCHEDULED RUNS ARE FROZEN (Phase 0 of the agent-strength rescue,
+# docs/agent-strength-rebuild/MASTER_PLAN.md, decision D-003): the every-6-hours
+# cron was removed on 2026-07-12 so no uncontrolled training appends to the
+# corpora/ratings while the improvement loop is being rebuilt and re-validated.
+# Manual, attended runs via workflow_dispatch remain available. Do not restore the
+# cron without a passed Phase 7+ gate (see DECISIONS.md D-003 revisit conditions).
 
 on:
-  schedule:
-    # Every 6 hours at :00 (00/06/12/18 UTC) — ~20h/day of training with a ~1h
-    # buffer between runs for eval, reports, commit-back, and email. The
-    # `concurrency` block below queues (does not cancel) any overlap.
-    - cron: "0 */6 * * *"
   workflow_dispatch:
     inputs:
       approaches:

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,10 @@ docs.
 > verdicts, pre-July-2026 champion narratives) predate the maxⁿ reward fix and
 > are **not valid** as evidence about which MCTS features help.
 
+- **agent-strength-rebuild/** — **governing plan for all agent-strength work
+  (July 2026 rescue): start at
+  [`agent-strength-rebuild/MASTER_PLAN.md`](agent-strength-rebuild/MASTER_PLAN.md)**;
+  supersedes `05-planning/CONTINUOUS_TRAINING_PLAN.md` for strategy.
 - **00-overview/** — documentation map and orientation.
 - **01-product/** — feature inventory and current-behavior notes.
 - **02-architecture/** — engine / MCTS / webapi / frontend architecture.

--- a/docs/agent-strength-rebuild/AUDIT_INVENTORY.md
+++ b/docs/agent-strength-rebuild/AUDIT_INVENTORY.md
@@ -1,0 +1,122 @@
+# Audit Inventory — Component Trust Classification
+
+Classification of every major subsystem, in the required audit format.
+Confidence levels: Trusted / Mostly trusted / Unverified / Suspect / Known incorrect / Obsolete.
+Migration actions: Reuse / Validate before reuse / Refactor / Rewrite / Remove / Archive.
+
+Baseline commit: `cabe2dd7738daca661798d422ee487179640e34f` (2026-07-12).
+
+---
+
+## Engine — board & rules core
+
+- **Subsystem:** Board state, move application, scoring
+- **Location:** `engine/board.py` (674 lines), `engine/game.py` (465), `engine/pieces.py` (513), `engine/bitboard.py` (213)
+- **Purpose:** Blokus rules: dual grid+bitboard state, placement, frontier tracking, turn order, terminal detection, scoring/ranking
+- **Current implementations:** one; deliberately redundant internal paths (grid vs bitboard legality) kept for differential testing
+- **Dependencies:** numpy only
+- **Inputs/Outputs:** positions/pieces/players → mutated board, scores, `GameResult`
+- **Correctness risks:** standard **+5 monomino-last bonus missing** from `Board.get_score` (board.py:562) although `AUDIT_REPORT.md` §3.8 claims scoring verified; default scoring mode is non-standard "house" (+5/corner, +2/center; game.py:25-38); incremental frontier is a correctness-sensitive cache (has a rebuild reconciler + tests); engine does not auto-skip blocked players (pass handling lives in callers — MCTS tree, rollout loop, `webapi/game_manager.py`)
+- **Performance risks:** none blocking; `Board.copy()` is the MCTS hot path
+- **Data risks:** none
+- **Tests present:** `tests/test_engine.py`, `test_game_over_logic.py`, `test_game_result.py`, `test_frontier_basic.py` (incremental-vs-rebuild differential), `test_bitboard_basic.py`, `test_pieces_orientations.py`, `test_piece_shapes_match.py`, `test_pass_turn.py`
+- **Tests missing:** property-based invariants (hypothesis), full-game reference↔optimized trajectory differential, standard-scoring tests incl. monomino bonus, serialization round-trip
+- **Observed defects:** missing monomino bonus (vs standard rules)
+- **Confidence:** Mostly trusted (as house-rules implementation); Suspect (as standard-rules implementation)
+- **Recommendation / Migration action:** **Validate before reuse** — Phase 2: standard scoring + property tests + full-game differential harness
+
+## Engine — legal move generation
+
+- **Subsystem:** Move generation & legality
+- **Location:** `engine/move_generator.py` (1309 lines)
+- **Purpose:** legal move enumeration (frontier-based fast path; naive full-scan reference), bitboard/grid legality, `sample_legal_moves` for rollouts
+- **Correctness risks:** three coexisting bitboard legality functions + grid path — equivalence currently test-enforced; env flags (`USE_FRONTIER_MOVEGEN`, `USE_BITBOARD_LEGALITY`, `USE_HEURISTIC_ANCHORS`) read at **import time** (move_generator.py:63-88) — config drift/repro risk; module-level shared generator singleton (write-once caches, read-safe)
+- **Performance risks:** movegen dominates search cost (prior audit); already ~6× improved via sampled rollouts
+- **Tests present:** `test_move_generation_equivalence.py` (frontier vs naive, incl. random midgame), `test_legality_bitboard_equivalence.py` (bitboard vs grid)
+- **Tests missing:** equivalence under every env-flag combination; property tests
+- **Confidence:** Mostly trusted
+- **Recommendation:** **Validate before reuse** — designate naive+grid as the Phase 2 reference implementation; later move env flags to explicit config
+
+## Search — canonical MCTS agent
+
+- **Subsystem:** `MCTSAgent` + `MCTSNode`
+- **Location:** `mcts/mcts_agent.py` (2452 lines)
+- **Purpose:** the one production/search implementation: UCT selection, maxⁿ per-player vector backprop, configurable rollouts/leaf evals
+- **Correctness risks:** post-fix maxⁿ semantics look right (`_backpropagation:2231` credits each node with the mover's reward; regression suite exists) but strength-vs-compute is **unproven** (Phase 4 gate); reward scale O(100) with C=1.414 is a deliberate but fragile near-greedy calibration; wall-clock budget mode is nondeterministic (repo convention avoids it); `_history_table`/`_nst_table` persist across moves within a game
+- **Performance risks:** no tree reuse (rebuilds root each move — acceptable per plan until Phase 10); Zobrist hash recomputed O(400)/call
+- **Tests present:** `test_maxn_backprop.py`, `test_tactical_positions.py`, `test_move_policy.py`, layer suites (3/5/6/7/8/9), `test_agent_interface_contract.py`, `test_agent_timeout_behavior.py`
+- **Tests missing:** node-statistics assertions on hand-authored near-terminal positions at scale; scaling benchmark; determinism test matrix
+- **Confidence:** core loop Mostly trusted; **experimental layers Unverified** (all pre-fix conclusions invalid)
+- **Recommendation:** **Validate before reuse** (core, Phase 3–4). Experimental layers (RAVE, NST, minimax-backup, PW, opponent modeling, adaptive meta, tree-parallel): **Archive-in-place** — keep off, re-admit only via post-fix experiments; candidates for code removal in a later cleanup if Phase 10 doesn't resurrect them
+
+## Search — supporting evaluators & policy
+
+- **Location:** `mcts/state_evaluator.py` (Layer-6, 8 features, tanh squash), `mcts/rich_leaf_evaluator.py` (45-feature TD), `mcts/learned_evaluator.py`, `mcts/move_heuristic.py`, `mcts/move_policy.py` (log-linear, 4 features + per-piece bias), `mcts/search_profiles.py`
+- **Correctness risks:** evaluator scale interacts with exploration constant; move policy top-1 agreement only 0.53 and self-distils toward the fixed heuristic (AUDIT_REPORT §7)
+- **Confidence:** Mostly trusted mechanically; Unverified for strength contribution
+- **Recommendation:** **Validate before reuse** (Phase 5 decides the leaf-eval path); `move_policy` expected to be **superseded** by the Phase 6 model
+
+## Search — parallelism & transposition
+
+- **Location:** `mcts/parallel.py` (root-parallel, derived seeds), tree-parallel path in `mcts_agent.py`, `mcts/zobrist.py` (TT, deterministic-only caching)
+- **Correctness risks:** tree-parallel has documented races (GIL-tolerated) — excluded from trusted path; root-parallel is deterministic by construction but adds variance to merged stats
+- **Recommendation:** root-parallel **Reuse** (teacher self-play throughput); tree-parallel **Archive** (do not use); TT **Reuse** as-is (deterministic-only)
+
+## Agents & registry
+
+- **Location:** `agents/{champion,heuristic_agent,random_agent,registry,base_agent,gameplay_protocol,interface}.py`
+- **Correctness risks:** `agents/champion.py` reads `data/champion_registry.json` (v2 "key_findings_best") while training's champion is `training/state/champion.json` (gen140) — **two disagreeing sources of truth**; serving champion is NOT the validated training champion
+- **Confidence:** Mostly trusted mechanically; Suspect as lineage
+- **Recommendation:** **Reuse** code; **Decision required (Phase 9)** on a single promotion path training→serving
+
+## Evaluation & arena
+
+- **Location:** `analytics/tournament/{arena_runner,gauntlet,elo,trueskill_rating,...}.py`, `training/evaluation/{benchmark_pool,head_to_head,sequential,promotion_gate}.py`, `mcts_lab/eval.py`
+- **Purpose:** seeded 4-seat arenas, benchmark_v2 pool, TrueSkill(PlackettLuce)+Elo+Wilson CI, Wald SPRT sequential screen, two-stage promotion gate
+- **Correctness risks:** Elo-from-pairwise decomposition in a 4-player game is a known approximation (TrueSkill is primary — keep it that way); default seat policy `randomized` (round_robin exists and is used by SPRT — protocol should require it); screen noise ±72 Elo documented at small game counts
+- **Tests present:** promotion gate, sequential eval, ratings, TrueSkill suites in `tests/`
+- **Confidence:** Mostly trusted — the strongest part of the lab
+- **Recommendation:** **Reuse**; codify as `BENCHMARK_PROTOCOL.md`; add matchup-matrix retention + non-transitivity checks (Phase 9)
+
+## Training pipeline & approaches
+
+- **Location:** `training/nightly_run.py`, `training/selfplay_core.py`, `training/approaches/*` (baseline, heuristic_tuning, mcts_param_sweep, td_learning, hybrid, policy_prior, progressive_widening, rich_leaf), `training/{td_learning,policy_learning,policy_selfplay,data_refresh}.py`
+- **Correctness risks:** the approaches are linear refits over small corpora with **no held-out evaluation**; empirically they have produced 0 promotions in 39 generations and uniformly negative deltas — the approach family, not the plumbing, is the suspect
+- **Data risks:** corpora are append-only CSVs; `--refresh-data` recency-caps but era-mixing is possible (see `DATA_LINEAGE.md`)
+- **Confidence:** pipeline plumbing Mostly trusted (durable resume, atomic writes); approach *effectiveness* Suspect
+- **Recommendation:** plumbing **Reuse**; approaches **Archive** as experiments — the Phase 6–8 policy/value loop replaces them as the candidate source
+
+## State & ratings persistence
+
+- **Location:** `training/state/{champion.json,latest.json,ratings.sqlite,checkpoints/,policy_weights.json,td_evaluator_weights.json,rich_leaf_weights.json}`, `training/{state_store,ratings_db,reporting_era}.py`
+- **Confidence:** Mostly trusted (append-only DB, atomic saves, era cutoffs already implemented)
+- **Recommendation:** **Reuse**; assets pinned by hash in `DATA_LINEAGE.md`
+
+## Data corpora
+
+- **Location:** `data/{champion_snapshots,td_trajectories,policy_targets}.csv`, `data/archive/`
+- **Confidence / status:** per-file compatibility table in `DATA_LINEAGE.md` (pre-fix archive Incompatible; snapshots Suspect; td_trajectories Verified-tagged; policy_targets Suspect)
+- **Recommendation:** **Archive** for the new loop — Phase 7 datasets start fresh with manifests; legacy corpora stay for the existing approaches only
+
+## Automation
+
+- **Location:** `.github/workflows/nightly-mcts-training.yml` (cron every 6 h — ACTIVE at baseline), `.claude/commands/run-overnight-mcts.md` (already promotion-guarded, manual)
+- **Recommendation:** cron **Remove** (Phase 0; keep `workflow_dispatch`); skill **Reuse**
+
+## Serving (webapi / frontend / browser bundle)
+
+- **Location:** `webapi/`, `api-runtime/`, `frontend/`, `browser_python/worker_bridge.py`, `scripts/build_browser_core.sh`
+- **Notes:** one-directional dependency UI→core; Pyodide bundle is a verbatim copy of `engine/ mcts/ agents/` (numpy-only constraint for Phase 6)
+- **Confidence:** out of scope for strength work
+- **Recommendation:** **Defer** — untouched until Phase 10/production integration
+
+## Analytics / metrics / telemetry
+
+- **Location:** `analytics/{logging,metrics,aggregate,winprob}`, `engine/{telemetry,advanced_metrics,mobility_metrics}.py`
+- **Recommendation:** **Reuse** passively; not on the critical path
+
+## Docs
+
+- **Location:** `docs/` numbered buckets
+- **Observed defects:** `docs/00-overview/DOCUMENTATION_INDEX.md` links many deleted files (hygiene debt, non-blocking)
+- **Recommendation:** `docs/agent-strength-rebuild/` is now the governing planning layer; `docs/05-planning/CONTINUOUS_TRAINING_PLAN.md` is superseded for strategy (kept as history)

--- a/docs/agent-strength-rebuild/BENCHMARK_PROTOCOL.md
+++ b/docs/agent-strength-rebuild/BENCHMARK_PROTOCOL.md
@@ -1,0 +1,64 @@
+# Benchmark Protocol
+
+**Protocol version:** `rescue_v1` (2026-07-12). Any change to pool, seeds, budgets, seat policy,
+or scoring mode requires a version bump recorded here and referenced in every experiment entry.
+Raw match outcomes and matchup matrices are the primary evidence; every rating is a summary.
+
+## Fixed conditions (rescue_v1)
+
+| Condition | Value | Source |
+|---|---|---|
+| Opponent pool | `benchmark_v2`: heuristic, random, `baseline_mcts_fast` (100 ms-equiv), `baseline_mcts_strong` (500 ms-equiv), `best_historical` checkpoint | `training/evaluation/benchmark_pool.py` |
+| Seeds | `20260620, 20260621` (nightly convention); pool defaults `20260101, 20260202` where the code requires them | `mcts_lab/eval.py`, `benchmark_pool.py` |
+| Seat policy | `round_robin` (required — cancels first-move advantage deterministically; `randomized` allowed only for exploratory runs, never gates) | `analytics/tournament/arena_runner.py` |
+| Move budget | **Iteration-deterministic** (`deterministic_time_budget` + `iterations_per_ms`), never wall-clock, for anything feeding a gate | `mcts/search_profiles.py`, repo convention |
+| Scoring mode | house (historical) until Phase 2 lands standard scoring; then `SCORING_MODE_STANDARD` and protocol bumps to `rescue_v2` | D-002 |
+| Minimum games | screen ≥ 20; confirmation ≥ 60; SPRT cap 160 paired games/candidate | `promotion_gate.py`, `sequential.py` |
+| Statistics | Wilson 95% CI on win rate; TrueSkill (PlackettLuce) μ/σ, conservative = μ−3σ; Wald SPRT α=β=0.05; paired permutation test | existing implementations |
+| Hardware note | record runner class (GitHub-hosted 2-core vs local) in every experiment entry | — |
+
+## Required metrics per evaluation (master prompt §5)
+
+First-place rate; average finishing position; final normalized score; score margin; placement
+distribution; per-seat performance; per-opponent-composition performance; head-to-head /
+mixed-table matrix; CI or equivalent uncertainty; runtime per move; simulations per move;
+(once a model exists) inference time; search throughput; memory; TrueSkill summary (+ Elo as a
+legacy secondary).
+
+Most of these are already emitted by `analytics/tournament/arena_runner.py` summaries and
+`mcts_lab/eval.py`; gaps (placement distribution, per-seat breakdown surfaced per run) are
+Phase 3/4 deliverables of the node-stats/benchmark tooling.
+
+## Canonical commands
+
+```bash
+# Sanity gate before any benchmark
+python -m mcts_lab.checks
+
+# Standard evaluation (pooled, seeded)
+python -m mcts_lab.eval --agents champion,baseline --games 10 --seeds 20260620,20260621
+
+# Candidate promotion (two-stage, never bypass)
+python -m mcts_lab.promote --candidate training/artifacts/candidates/<artifact>.json
+
+# Search-quality diagnostic (Phase 4 starting point)
+python -m training.diagnostics.search_quality   # see training/diagnostics/
+```
+
+## Rules
+
+1. **No gate decision from a single rating number.** Promotion and phase gates cite game counts,
+   CIs/SPRT verdicts, and the matchup matrix.
+2. **Never change benchmark conditions mid-experiment.** A changed condition = new protocol
+   version = results not comparable.
+3. **Benchmark agents are immutable.** Pool members are pinned configs/checkpoints; replacing
+   one is a protocol version bump.
+4. **Seat balance is mandatory** for gates (round_robin), and per-seat results must be reported.
+5. **Determinism:** fixed seeds, iteration budgets, single-thread search for gate games
+   (root-parallel allowed for data generation, not for gate evaluation unless separately
+   validated).
+6. **Reproducibility block** (per `EXPERIMENT_LOG.md` template) is required for every run used
+   as evidence: commit, seeds, configs, hardware, game counts, artifacts.
+7. **Era hygiene:** results from before the maxⁿ fix (`DEBUGGED_BACKPROP_EPOCH_RUN_ID =
+   20260701T204805Z`) are never mixed into current comparisons; post-Phase-2 (standard scoring)
+   results are likewise never mixed with house-scored ones.

--- a/docs/agent-strength-rebuild/CURRENT_STATUS.md
+++ b/docs/agent-strength-rebuild/CURRENT_STATUS.md
@@ -1,0 +1,30 @@
+# Current Status
+
+_Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 / master prompt §3)._
+
+## Session 2026-07-12 (session 1 — plan, freeze, audit)
+
+- **Current phase:** Phase 0 (freeze) + Phase 1 (forensic audit), executed together this session
+  after the documentation-only checkpoint commit.
+- **Current phase gate:**
+  - Phase 0: no uncontrolled training scheduled; assets pinned; legacy data labeled.
+    Status: **PARTIAL — BLOCKED on merge** (cron removal only takes effect on `main`; see
+    `phases/PHASE_0_FREEZE.md`).
+  - Phase 1: pipeline mapped, risks ranked, repo strategy decided. Status: **PASS**
+    (see `phases/PHASE_1_FORENSIC_AUDIT.md`).
+- **Most recent validated result:** EXP-000 baseline — champion gen140, Elo 1388.55,
+  TrueSkill μ 54.39 σ 5.02; 39-generation promotion drought; all current candidates negative
+  vs champion (`EXPERIMENT_LOG.md`).
+- **Current blockers:** PR merge required to activate the nightly freeze on `main`.
+- **Session objective:** documentation-only master-plan checkpoint → Phase 0 freeze →
+  Phase 1 audit report. No engine/search/training code changes.
+- **Files changed this session:** `docs/agent-strength-rebuild/**` (new),
+  `.github/workflows/nightly-mcts-training.yml` (cron removed, dispatch kept),
+  `docs/README.md` (index line).
+- **Experiments planned/run:** EXP-000 (baseline snapshot, no new games).
+- **Tests added:** none (docs + workflow-trigger change only). `python -m mcts_lab.checks`
+  re-run as regression evidence.
+- **Gate status summary:** Phase 0 PARTIAL — BLOCKED (merge); Phase 1 PASS.
+- **Next recommended task:** Phase 2 — implement standard scoring (+5 monomino-last bonus,
+  `SCORING_MODE_STANDARD` default for new evaluation) with unit tests, then the property-test
+  suite and full-game reference↔optimized differential harness. See `HANDOFF.md`.

--- a/docs/agent-strength-rebuild/DATA_LINEAGE.md
+++ b/docs/agent-strength-rebuild/DATA_LINEAGE.md
@@ -1,0 +1,73 @@
+# Data Lineage
+
+Rules and inventory for every dataset and model artifact. Governing rules:
+
+1. **Datasets are immutable once finalized.** New examples go to a new version or an
+   append-only shard with explicit provenance — never silently into an old corpus.
+2. **Never mix incompatible data**: different engines, encodings, value definitions, search
+   semantics/configs, or model generations require separate, manifested datasets.
+3. **Every Phase 7+ dataset carries a manifest** (schema version, engine version, generating
+   commit, checkpoint hash, search config, seeds, game/position counts, validator result).
+4. **New systems do not load legacy corpora by default.** The Phase 6–8 loop starts from fresh,
+   manifested teacher data; the legacy CSVs below remain only for the legacy approaches.
+
+## Era boundaries (already implemented in `training/reporting_era.py`)
+
+| Boundary | Run ID | Meaning |
+|---|---|---|
+| maxⁿ backprop fix | `DEBUGGED_BACKPROP_EPOCH_RUN_ID = 20260701T204805Z` (gen 139, commit `732bd9c`) | Anything earlier used the cooperating-opponents search — invalid for strength conclusions |
+| Multi-agent framework | `MULTI_AGENT_EPOCH_RUN_ID = 20260626T055723Z` | Reporting-era cutoff for approach comparisons |
+| Rescue baseline | commit `cabe2dd7738daca661798d422ee487179640e34f` (2026-07-12) | All hashes below pinned at this commit |
+
+## Frozen-asset inventory (sha256 @ rescue baseline)
+
+**Caveat:** until the Phase 0 workflow change merges to `main`, the 6-hourly nightly job may
+keep appending to the CSVs and ratings DB on `main`. These hashes identify the rescue-baseline
+snapshot; the baseline commit SHA is the authoritative pin (git history preserves every prior
+state).
+
+### Data corpora (`data/`)
+
+| File | sha256 | Compatibility |
+|---|---|---|
+| `champion_snapshots.csv` (~1.5k rows, per-ply Layer-6/se_* features + outcome labels) | `ad5322ee34e7e2cb01a4fb28cd5614677814ca0125db8e1bfd71f0f1451ebcdd` | **Suspect** — era-mixed accumulation; post-fix rows not separable without join on run metadata; usable only for legacy `heuristic_tune` refits |
+| `td_trajectories.csv` (~2.1k rows, 45 `f_*`/`nf_*` features, `agent_version`, `feature_set_version=rich_blokus_v1`) | `e46c81461f7f48254dc06d087b2be8cd957e571cf850a8a1ca9d501cddd69cad` | **Verified-tagged** — rows carry generating agent/budget tags; filterable by era |
+| `policy_targets.csv` (~75k rows, root visit counts, grouped by `decision_id`) | `e420bf0ffde2c62a7172536d5db3c45e9d80a87f2202cfabf93df0117af305e0` | **Suspect** — no era/agent column; collection spans budgets (old 40 ms near-random rows + teacher rows indistinguishable) |
+| `champion_registry.json` (serving registry, `current_version: v2`) | `561a45fa4fb737fb424555faf4f729945f6878a501c7fb13781700d5c536f6c4` | **Verified** as serving state; lineage split from training champion (D-009) |
+| `layer6_calibrated_weights.json` | `412231ffc0c49a26ac54089e7dd2812bc67d2b36eceedb47cd883ff3511207d3` | **Verified** artifact |
+| `archive/champion_snapshots_pre_searchfix_gen140.csv.gz` | `40ad30eee3f8ceb18ba83cbb068e8f6e03d8f94092b2238e815fe780e4d58b12` | **Incompatible** — pre-maxⁿ-fix; forensic use only |
+| `archive/README.md` | `08c3dd56618db7026af44a70c42b3a8d921b8b804c7f369bfecf2c3811d6e0eb` | — |
+
+### Training state (`training/state/`)
+
+| File | sha256 | Compatibility |
+|---|---|---|
+| `champion.json` (gen140, promoted 2026-07-02; Elo 1388.55, μ 54.39 σ 5.02) | `baf1ed68b163fc45c1dc04adf19725b87c3a9be24e0de590219b4f0c506eb26d` | **Verified** — post-fix gated promotion |
+| `latest.json` (generation 179, 6 290 games, last_promoted 140) | `82ed0bac9f1428545a89fb01cb56e2673e322fc6e361b56a16587246568330cc` | **Verified** durable state |
+| `checkpoints/champion_gen140.json` | `2b50f351e302cb19513003c457df54b15ed677a79b830232d83a3e2fb99437c1` | **Verified** — immutable historical anchor |
+| `ratings.sqlite` (append-only, SCHEMA_VERSION 2) | `6e6a8f1d065d90a082af20076a130cae082f849786376f534674ac6a1e3d92c2` | **Verified** with era filtering; pre-fix rows excluded from trends by `reporting_era.py` |
+| `policy_weights.json` (log-linear move policy, top-1 agreement 0.53) | `07a2ba90f738918ac3b5f2a29d683615d2026b0e9ca7b786df678e54622ef3dd` | **Suspect** for strength (self-distils toward fixed heuristic, AUDIT_REPORT §7); mechanically valid |
+| `td_evaluator_weights.json` (45-feature TD, full subset, 732 rows) | `2860a0791d957f272a2c7413aea687c34d1d64f6e84a8b843373c4806d73a7cc` | **Unknown** strength value; post-fix data |
+| `rich_leaf_weights.json` (TD, score subset, 2 120 rows) | `0dbdbd3f46341ed6199251417a2795ec33ec56b4b8e3e5ca985d02dbe4220b48` | **Unknown** strength value; its candidate lost to champion (−60 Elo, run 20260711T190001Z) |
+
+### Not versioned
+
+Per-game `training/state/selfplay_runs/*/games.jsonl` are gitignored (bulk). Consequence:
+historical per-game records exist only for runs still on disk somewhere — treat as absent.
+Phase 7 datasets must version (or manifest-hash) their game records.
+
+## Compatibility status legend
+
+- **Verified** — provenance and generating code understood; safe for its stated purpose.
+- **Suspect** — usable with care; era or budget mixing possible; never feed the new loop.
+- **Incompatible** — generated under known-wrong semantics (pre-maxⁿ fix); forensic only.
+- **Unknown** — mechanically valid, strength value unmeasured.
+
+## Phase 7 dataset requirements (forward-looking)
+
+Every new self-play record: dataset schema version, engine version, game id, position index,
+full state, current player, legal actions, visit counts, normalized policy target, root values,
+final score + placement vectors, selected action, search config, model checkpoint hash, seed,
+seat mapping, symmetry transform (if any). A `training/` dataset validator must check legality
+of selected actions, policy/legal-action alignment, player-vector ordering, terminal-score
+agreement with the engine, and manifest/record consistency before any training run consumes it.

--- a/docs/agent-strength-rebuild/DECISIONS.md
+++ b/docs/agent-strength-rebuild/DECISIONS.md
@@ -1,0 +1,90 @@
+# Decision Records
+
+Format per governing master prompt §21. Statuses: Proposed / Accepted / Superseded.
+
+---
+
+## D-001 — Repository strategy: stay in the current repo
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Context:** The master prompt allows a rewrite or a new agent-focused repo. The July 2026
+  cleanup already reduced the lab to one engine and one MCTS implementation.
+- **Options considered:** (a) new `agent-core` repo inheriting validated pieces; (b) stay here
+  with `docs/agent-strength-rebuild/` as the governing layer.
+- **Evidence:** single engine/search implementations with real differential + regression tests
+  (`tests/test_move_generation_equivalence.py`, `test_legality_bitboard_equivalence.py`,
+  `test_maxn_backprop.py`); UI coupling is one-directional (webapi/frontend import core, never
+  the reverse); evaluation infra (TrueSkill/SPRT/gate) is the strongest subsystem and would have
+  to be ported wholesale; no neural training stack exists yet to isolate.
+- **Decision:** stay in `MCTS_Laboratory`. Legacy experiment surfaces are archived-in-place via
+  `AUDIT_INVENTORY.md` classifications rather than physically moved.
+- **Consequences:** less migration risk and immediate reuse of eval infra; discipline required
+  to keep new datasets/models from silently mixing with legacy ones (see `DATA_LINEAGE.md`).
+- **Revisit conditions:** Phase 6 model work makes the Pyodide/serving coupling or repo weight a
+  concrete obstacle; or the archive surfaces materially slow CI/test cycles.
+- **Related:** `MASTER_PLAN.md` §3, `AUDIT_INVENTORY.md`.
+
+## D-002 — Target ruleset: standard Blokus scoring
+
+- **Date:** 2026-07-12
+- **Status:** Accepted (explicit user decision, session 1)
+- **Context:** Engine default is the non-standard "house" mode (+5/controlled corner,
+  +2/center square; `engine/game.py:25-38`). Standard Blokus is coverage + 15 all-pieces bonus
+  + 5 monomino-last. The monomino bonus is **not implemented** in `Board.get_score`
+  (`engine/board.py:562`), although `AUDIT_REPORT.md` §3.8 claims scoring was verified.
+  The project goal is beating a skilled human, who plays standard rules.
+- **Options considered:** standard (implement bonus, retarget); keep house; defer to Phase 2
+  experiments.
+- **Decision:** **Standard Blokus scoring** is the training/evaluation objective. Phase 2
+  implements the monomino-last bonus and makes `SCORING_MODE_STANDARD` the default for all new
+  evaluation. House mode remains available for historical comparability only.
+- **Consequences:** historical arena results (house-scored) are not directly comparable to
+  post-Phase-2 results; benchmark baselines must be re-anchored under standard scoring
+  (recorded in `BENCHMARK_PROTOCOL.md` as a protocol version bump when it happens).
+- **Revisit conditions:** none anticipated; a product decision to ship house-rules play would
+  add a secondary objective, not replace this one.
+- **Related:** Phase 2 in `MASTER_PLAN.md`; risk #3 in the Phase 1 report.
+
+## D-003 — Phase 0 freeze method: drop the cron, keep workflow_dispatch
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Context:** `.github/workflows/nightly-mcts-training.yml` runs every 6 h with
+  `contents: write`, appending corpora and refreshing ratings — exactly the uncontrolled data
+  generation Phase 0 must stop.
+- **Options considered:** delete the workflow; disable via repo UI (not reproducible in-code);
+  remove `schedule:` and keep `workflow_dispatch`.
+- **Decision:** remove the `schedule:` trigger, keep `workflow_dispatch` so deliberate,
+  attended runs remain possible with the full input surface.
+- **Consequences:** **GitHub reads cron schedules from the default branch — the freeze takes
+  effect only when this branch merges to `main`.** Until then, 6-hourly runs continue and may
+  append to corpora/ratings; the asset hashes in `DATA_LINEAGE.md` are pinned to the baseline
+  commit, so later drift is detectable.
+- **Revisit conditions:** the Phase 7+ pipeline earns back a scheduled run under the new gates.
+- **Related:** `phases/PHASE_0_FREEZE.md`.
+
+## D-004 — Branch naming: harness-designated branch
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Context:** The generic master prompt suggests `agent-rescue/phase-*` branches; the execution
+  environment designates `claude/agent-rescue-master-plan-i9kvwf` and forbids pushing elsewhere.
+- **Decision:** all rescue work develops on the designated branch (per session), merged to
+  `main` via PR; phase identity is carried by commit messages and `phases/` reports instead of
+  branch names.
+- **Related:** session protocol in `CURRENT_STATUS.md`.
+
+---
+
+## Open decisions (required before their phases)
+
+| ID (reserved) | Topic | Needed by | Notes |
+|---|---|---|---|
+| D-005 | Multiplayer value target (normalized score vs placement vs pairwise vs mixed) | Phase 6 | Requires a Phase 5/6 experiment, not a preference |
+| D-006 | Model framework & serving path (train-anywhere + numpy inference vs numpy-native; Pyodide constraint) | Phase 6 | Browser bundle currently ships numpy only |
+| D-007 | State/action encoding schema (versioned) | Phase 6/7 | Candidate-scoring action representation preferred |
+| D-008 | Teacher search budget | Phase 7 | Output of the Phase 4 scaling study |
+| D-009 | Single champion lineage: training state vs `data/champion_registry.json` serving registry | Phase 9 | Two sources of truth currently disagree (gen140 vs v2) |
+| D-010 | Production latency target & difficulty modes | Phase 10 | Measure first |
+| D-011 | Rating methodology confirmation (TrueSkill-primary, matrices as evidence) | Phase 9 | Existing practice, needs a formal record |

--- a/docs/agent-strength-rebuild/EXPERIMENT_LOG.md
+++ b/docs/agent-strength-rebuild/EXPERIMENT_LOG.md
@@ -1,0 +1,55 @@
+# Experiment Log
+
+Record experiments **when they run**, not afterward. Never overwrite an entry; corrections are
+appended. Every entry uses the template below (from the governing master prompt §3).
+
+```
+Experiment ID:
+Date:
+Commit:
+Hypothesis:
+Independent variable:
+Controlled variables:
+Agents:
+Game count:
+Seat-balancing method:
+Seeds:
+Hardware:
+Result:
+Uncertainty:
+Interpretation:
+Decision:
+Artifacts:
+```
+
+---
+
+## EXP-000 — Rescue baseline snapshot (no new games played)
+
+- **Experiment ID:** EXP-000
+- **Date:** 2026-07-12
+- **Commit:** `cabe2dd7738daca661798d422ee487179640e34f`
+- **Hypothesis:** n/a — reference snapshot of the frozen system's last recorded performance.
+- **Independent variable:** none.
+- **Controlled variables:** all values read from committed durable state
+  (`training/state/latest.json`, `training/status.md`, run `20260711T190001Z`).
+- **Agents:** champion gen140 vs benchmark_v2 pool + candidates rich_leaf / heuristic_tune /
+  mcts_sweep.
+- **Game count:** cumulative 6 290 (generation 179); last run: 48–56 paired games/candidate.
+- **Seat-balancing method:** round_robin (SPRT sequential screen).
+- **Seeds:** 20260620, 20260621.
+- **Hardware:** GitHub-hosted 2-core runner (nightly workflow).
+- **Result:** champion gen140 Elo 1388.55, TrueSkill μ 54.39 σ 5.02 (conservative 39.33). Last
+  run candidates all HELD, SPRT inconclusive, all negative vs champion: rich_leaf 56 games,
+  39% win vs champ, ΔElo −60.1, Δμ −9.62; heuristic_tune 48 games, ΔElo −117.3, Δμ −9.71;
+  mcts_sweep 48 games, ΔElo −108.4, Δμ −10.54. Best historical Elo 1418.1 (gap −29.5, within
+  documented rating noise σ≈±42.5). 39 generations without promotion.
+- **Uncertainty:** rating noise at nightly game counts documented at ±42–72 Elo; SPRT verdicts
+  inconclusive (neither H0 nor H1).
+- **Interpretation:** the plateau is real at the current approach family's effect size:
+  candidates are consistently *weaker* than the champion, not undetectably better. Supports
+  risk ranking #2 (candidate generation exhausted) and motivates Phases 4–8 rather than more
+  nightly iterations.
+- **Decision:** freeze (Phase 0); proceed per `MASTER_PLAN.md`.
+- **Artifacts:** `training/state/latest.json` (`last_approach_comparison`),
+  `training/status.md`, `training/reports/approach_comparison.md`, hashes in `DATA_LINEAGE.md`.

--- a/docs/agent-strength-rebuild/HANDOFF.md
+++ b/docs/agent-strength-rebuild/HANDOFF.md
@@ -1,0 +1,63 @@
+# Handoff
+
+_For the next agent/session. Read `MASTER_PLAN.md`, `CURRENT_STATUS.md`, `DECISIONS.md`,
+`EXPERIMENT_LOG.md`, and this file before doing anything._
+
+## Where things stand (after session 1, 2026-07-12)
+
+- The governing plan, audit, decisions, protocol, and lineage docs all live in this directory.
+- Phase 0: cron trigger removed from `.github/workflows/nightly-mcts-training.yml`
+  (`workflow_dispatch` kept). **Not effective until the PR merges to `main`** — until then the
+  6-hourly nightly job keeps running and appending to `data/*.csv` + `training/state/`.
+  If the merge is delayed, expect drift from the `DATA_LINEAGE.md` hashes (baseline commit
+  `cabe2dd` is the authoritative pin).
+- Phase 1: audit complete — `AUDIT_INVENTORY.md` + `phases/PHASE_1_FORENSIC_AUDIT.md`.
+- Decisions taken: stay in this repo (D-001); **standard Blokus scoring is the target ruleset**
+  (D-002, explicit user decision); freeze method (D-003); branch naming (D-004).
+
+## Exact next action
+
+**Phase 2, task 1:** implement standard scoring correctly.
+
+1. Add the +5 monomino-last bonus to scoring (standard mode). Today `Board.get_score`
+   (`engine/board.py:562`) only has coverage + 15 all-pieces; `engine/game.py:25-38` defines
+   `SCORING_MODE_STANDARD`/`HOUSE` with house as default. The bonus needs "last piece played
+   was the monomino" state — check what `game_history` already records before adding board
+   state.
+2. Unit tests: all four bonus combinations (none / +15 / +5 / +20), both scoring modes,
+   ranking/`GameResult` under standard mode.
+3. Make standard mode the default for `mcts_lab.eval` / benchmark runs; bump
+   `BENCHMARK_PROTOCOL.md` to `rescue_v2` in the same commit; house mode stays available.
+4. Then: property-test suite (consider `hypothesis` — new dev dependency, record a decision)
+   and the full-game reference↔optimized differential harness
+   (naive movegen + grid legality vs frontier + bitboard, thousands of positions).
+
+## Commands to reproduce current results
+
+```bash
+python -m mcts_lab.checks                      # fast sanity gate (must pass before/after any change)
+python -m pytest tests/ -q -n 4                # full suite (slow)
+python -m mcts_lab.eval --agents champion,baseline --games 10 --seeds 20260620,20260621
+sha256sum data/*.csv training/state/champion.json   # compare against DATA_LINEAGE.md
+```
+
+## Unresolved questions / known risks
+
+1. **Does more search produce stronger play post-fix?** (Phase 4 gate — the critical unknown;
+   prior audit measured effective depth-1 search at nightly budgets.)
+2. **Why are all candidates weaker than the champion?** Working hypothesis: the linear-refit
+   approach family is exhausted; alternative: an evaluation/config subtlety. Phase 4/5
+   experiments will discriminate.
+3. **Dual champion registries** (`training/state/champion.json` gen140 vs
+   `data/champion_registry.json` v2) — serving champion is not the validated training champion.
+   Decision D-009 reserved for Phase 9; do not "fix" this casually, the web demo depends on it.
+4. Nightly job may still run until merge (see above).
+5. `docs/00-overview/DOCUMENTATION_INDEX.md` has dead links (hygiene debt only).
+
+## Session protocol reminders
+
+- Update `CURRENT_STATUS.md` at session start/end; append experiments to `EXPERIMENT_LOG.md`
+  when they run; record decisions in `DECISIONS.md`; phase reports in `phases/`.
+- Never advance past a phase gate without evidence; failed gate → smallest distinguishing
+  experiment (no default escapes, master prompt §20).
+- Champion writes only via `mcts_lab.promote` / gated nightly path.

--- a/docs/agent-strength-rebuild/MASTER_PLAN.md
+++ b/docs/agent-strength-rebuild/MASTER_PLAN.md
@@ -1,0 +1,199 @@
+# Agent-Strength Rescue — Master Plan (repo-specific)
+
+**Status:** governing plan for all agent-strength work in this repo from 2026-07-12 onward.
+**Baseline commit:** `cabe2dd7738daca661798d422ee487179640e34f` (branch `claude/agent-rescue-master-plan-i9kvwf`, forked from `main`).
+**Companion docs:** `CURRENT_STATUS.md` (live state), `AUDIT_INVENTORY.md` (component trust map),
+`DECISIONS.md` (decision records), `EXPERIMENT_LOG.md`, `BENCHMARK_PROTOCOL.md`, `DATA_LINEAGE.md`,
+`HANDOFF.md`, `phases/` (per-phase reports).
+
+## 0. Objective
+
+Build the strongest practical 4-player Blokus agent this repo can produce, and a system that
+repeatedly yields validated, stronger generations. Success is defined by evidence, in this order:
+
+1. Engine correctness → 2. Search correctness → 3. Search scaling (more compute ⇒ stronger play)
+→ 4. Model learns correct targets → 5. Search beats raw model → 6. Trained model improves search
+→ 7. Generation N+1 beats N → 8. Fixed champion gate → 9. Practical latency → 10. Beats the
+target human skill level.
+
+The prior question — "did the latest nightly run raise Elo?" — is retired as a success signal.
+
+## 1. Where this repo actually is (July 2026)
+
+- Champion **gen140** (promoted 2026-07-02): Elo 1388.6, TrueSkill μ 54.39 σ 5.02
+  (`training/state/champion.json`). Generation 179, 6 290 games, **39-generation promotion
+  drought**; every recent candidate (rich_leaf, heuristic_tune, mcts_sweep) evaluated *below*
+  the champion (run `20260711T190001Z`: ΔElo −60 to −117).
+- The July 2026 audit (`AUDIT_REPORT.md`) already fixed the maxⁿ backprop bug, added a two-stage
+  SPRT promotion gate, and pruned the repo to one engine + one MCTS implementation.
+- There is **no neural network**. All learned components are linear/log-linear weight files fit
+  with sklearn/numpy (Layer-6 state evaluator, 45-feature TD value model, 4-feature move policy).
+- A GitHub Actions workflow trains **every 6 hours** and commits state back
+  (`.github/workflows/nightly-mcts-training.yml`) — Phase 0 freezes it.
+
+## 2. Actual subsystems, entry points, and assets
+
+| Subsystem | Location | Notes |
+|---|---|---|
+| Engine | `engine/{board,move_generator,game,pieces,bitboard}.py` | Dual grid+bitboard, incremental frontier; naive movegen + grid legality retained as reference paths |
+| Search | `mcts/mcts_agent.py` (only implementation) + `mcts/{state_evaluator,rich_leaf_evaluator,move_policy,parallel,zobrist,search_profiles}.py` | maxⁿ per-player vector backprop; experimental layers default off |
+| Agents | `agents/{champion,heuristic_agent,random_agent,registry}.py` | `agents/champion.py` reads `data/champion_registry.json` (serving), *not* `training/state/champion.json` |
+| CLI workflow | `python -m mcts_lab.{checks,eval,self_play,train,promote}` | Canonical commands (see root `CLAUDE.md`) |
+| Training pipeline | `training/nightly_run.py`, `training/selfplay_core.py`, `training/approaches/*` | Approach-comparison framework, durable resume |
+| Evaluation | `analytics/tournament/*` + `training/evaluation/{benchmark_pool,head_to_head,sequential,promotion_gate}.py` | benchmark_v2 pool, TrueSkill+Elo+Wilson+SPRT |
+| Data | `data/{champion_snapshots,td_trajectories,policy_targets}.csv`, weights in `training/state/*.json` | See `DATA_LINEAGE.md` for hashes and compatibility |
+| State | `training/state/{champion.json,latest.json,ratings.sqlite,checkpoints/}` | Append-only ratings DB, era cutoffs |
+| Serving | `webapi/` (FastAPI), `frontend/` (React+Pyodide), bundle via `scripts/build_browser_core.sh` | Browser path is numpy-only (Pyodide) — constrains Phase 6 model choices |
+| Automation | `.github/workflows/nightly-mcts-training.yml`, `.claude/commands/run-overnight-mcts.md` | The skill is already promotion-guarded; the cron is the freeze target |
+| Tests | `tests/` (76 files) | Differential engine tests exist; maxⁿ regression suite `tests/test_maxn_backprop.py`; no property-based framework |
+
+Reproduce the standard checks:
+
+```bash
+python -m mcts_lab.checks
+python -m pytest tests/ -q            # slow; use -n 4 while iterating
+python -m mcts_lab.eval --agents champion,baseline --games 10 --seeds 20260620,20260621
+```
+
+## 3. Repository strategy (Decision D-001)
+
+**Stay in this repository.** Rationale: exactly one engine and one search implementation survive
+the July 2026 cleanup, both carry real differential/regression tests; UI coupling is
+one-directional (webapi/frontend import the core, never the reverse); a new repo would duplicate
+validated code without removing any risk. The `docs/agent-strength-rebuild/` tree is the
+governing layer over the existing lab. Revisit condition: if Phase 6 model work makes the
+Pyodide/serving coupling or repo weight a real obstacle, extract an `agent-core` package then
+(see `DECISIONS.md` D-001 for the full record and scoring).
+
+## 4. Phases (repo-specific)
+
+Branch note (Decision D-004): all phases develop on the harness-designated branch
+`claude/agent-rescue-master-plan-i9kvwf` (merged to `main` via PR per phase or phase-group),
+not the `agent-rescue/phase-*` scheme from the generic master prompt.
+
+### Phase 0 — Freeze and preserve (this session)
+- Remove the `schedule:` cron from `nightly-mcts-training.yml`; keep `workflow_dispatch`.
+  **Effective only once merged to `main`** (GitHub reads schedules from the default branch).
+- Pin assets by sha256 + baseline commit (see `DATA_LINEAGE.md`); no copying needed — everything
+  durable is git-committed. Mark legacy-data compatibility.
+- Exit gate: no uncontrolled training remains scheduled; assets pinned; legacy data labeled.
+- Report: `phases/PHASE_0_FREEZE.md`.
+
+### Phase 1 — Forensic audit (this session, from completed exploration)
+- Full pipeline trace and risk-ranked findings: `phases/PHASE_1_FORENSIC_AUDIT.md`;
+  component trust map: `AUDIT_INVENTORY.md`.
+- Exit gate: every loop component has an identified owner/data path; risks ranked; repo strategy
+  decided (D-001).
+
+### Phase 2 — Trusted engine
+- Designate the existing **naive movegen + grid legality** path as the reference implementation
+  (`engine/move_generator.py::_get_legal_moves_naive`, `Board.can_place_piece`); do not write a
+  third engine.
+- Implement **standard Blokus scoring** as the target ruleset (Decision D-002): add the missing
+  +5 monomino-last bonus, make `SCORING_MODE_STANDARD` the default for all new evaluation;
+  house mode remains for historical comparability only.
+- Add property/invariant tests (evaluate `hypothesis`): occupancy monotonicity, piece-inventory
+  conservation, turn order, clone independence, serialization round-trip, terminal-implies-no-moves.
+- Extend differential tests to full-game trajectories (reference vs optimized: moves, states,
+  inventories, scores, rankings) at scale (thousands of positions).
+- Version the state/action formats (schema id surfaced in self-play records).
+- Exit gate: reference↔optimized agreement on large randomized sets; standard scoring tested;
+  formats versioned.
+
+### Phase 3 — Minimal trusted search
+- The post-fix `MCTSAgent` with **all experimental layers off** is the candidate minimal search
+  (plain UCT + maxⁿ vector backup, no tree reuse, deterministic-only TT, single thread,
+  iteration budgets). Task = verify, not rewrite: correctness tests on hand-authored tactical /
+  near-terminal / single-move / pass positions (extend `tests/test_tactical_positions.py`,
+  `tests/test_maxn_backprop.py`), plus a **node-statistics inspection CLI** (root visit counts,
+  Q per player, depth histogram — build on `mcts/search_trace.py`).
+- Contingency if verification fails: write a ~300-line reference MCTS for differential
+  comparison against `mcts_agent.py`.
+- Value semantics: per-player reward vector keyed by `Player`, mover-credited backup — already
+  the implemented convention; document exact meaning/range (currently O(100) score-scale +
+  win bonus; the [0,1] normalization was tried and reverted — any change needs an experiment).
+- Exit gate: deterministic under fixed seeds; maxⁿ semantics verified; terminal decisions correct.
+
+### Phase 4 — Search scaling gate (MANDATORY)
+- Same agent at increasing **iteration** budgets (e.g. 50/150/500/1 500/5 000 sims; plus
+  time-budget spot checks), fixed evaluator/opponents/seeds/seat protocol per
+  `BENCHMARK_PROTOCOL.md`. Builds on `training/diagnostics/search_quality.py`.
+- Prior audit found effective depth-1 search at nightly budgets (branching factor > iterations)
+  — this gate decides whether the current search converts compute into strength at all.
+- Exit gate: large budgets convincingly beat much smaller budgets; a viable slow **teacher
+  budget** is identified. If it fails: stop, diagnose (backup, eval signal, branching, ordering)
+  before any learning work.
+
+### Phase 5 — Rollout value audit
+- Equal-wall-clock comparison: static eval (cutoff 0) vs shallow vs deeper `greedy_sample`
+  rollouts vs rich-leaf (TD) evaluation. Question: stronger *decisions* per unit time, not
+  different numbers.
+- Exit gate: strongest practical leaf evaluation selected; demonstrably valueless rollout
+  depth removed from the core path.
+
+### Phase 6 — Policy/value model
+- Greenfield (no NN exists). Required decision records before building: framework (constraint:
+  Pyodide browser serving is numpy-only — options: train in torch/sklearn + export numpy
+  inference, or numpy-native model), value target (normalized score vs placement vs mixed),
+  action representation.
+- Preferred architecture: **legal-move candidate scoring** — encode state, encode each legal
+  move (engine-generated), score state×move pairs, softmax over legal moves only. This replaces
+  the current 4-feature log-linear policy (`training/state/policy_weights.json`, top-1 agreement
+  0.53) rather than extending it.
+- Gates: tiny-data overfit (few hundred positions) → held-out generalization → masking/ordering/
+  round-trip tests. Do not scale training before the overfit gate passes.
+
+### Phase 7 — Teacher self-play data pipeline
+- Teacher-budget search (from Phase 4) generates records: full state, legal actions, visit
+  counts, root values, final score+placement vectors, config, checkpoint hash, seed, seat map,
+  schema version. Extend `training/policy_selfplay.py` record format; add a dataset **validator**
+  and immutable **manifests** (see `DATA_LINEAGE.md` rules). New data never mixes with
+  pre-rebuild corpora by default.
+- Exit gate: validator-clean, fully traceable dataset that trains reproducibly.
+
+### Phase 8 — Improvement-loop gates (A–D)
+- A: net+search > net alone. B: new net alone > old net alone. C: same budget, new net > old net
+  in search. D: generation N+1 > N under the fixed protocol. All via `BENCHMARK_PROTOCOL.md`.
+- No continuous training system until all four arrows have evidence.
+
+### Phase 9 — Candidate/champion/league
+- Reuse and extend the existing machinery: two-stage gate (`training/evaluation/promotion_gate.py`
+  + `gauntlet.evaluate_promotion`), checkpoints as historical anchors, matchup matrices
+  (`training/reports/matchup_matrix.png` lineage). Add: explicit league manifest, promotion
+  criteria fixed *before* evaluation, non-transitivity monitoring.
+- Resolve the dual-registry split (training champion vs `data/champion_registry.json` serving
+  champion) with a documented promotion path to serving (Decision, Phase 9).
+
+### Phase 10 — Latency optimization
+- Only after Phase 8. Strength-vs-latency frontier; difficulty modes (instant/fast/standard/
+  expert); optimizations must pass semantic-equivalence regression tests. Tree reuse and
+  broader TT use are allowed here only with correctness proof.
+
+### Phase 11 — Human evaluation
+- Protocol per master prompt §18; `training/human_estimate.py`'s current "beginner, target
+  Elo 1700" extrapolation is replaced by real human games under recorded conditions.
+
+## 5. Initial risk ranking (detail in PHASE_1 report)
+
+1. **Search scaling unproven post-fix** — the whole learning plan is moot if Phase 4 fails.
+2. **Candidate generation exhausted** — linear refits consistently lose to the champion; the
+   ratchet needs Phases 5–7, not more nightly runs.
+3. **Wrong objective** — house scoring default vs the real (standard) game; monomino bonus
+   missing entirely (Phase 2, decided).
+4. **Dual champion sources of truth** — training vs serving registry disagree (Phase 9).
+5. **Determinism leaks** — wall-clock budgets, import-time env flags, tree-parallel mode
+   (avoid; codified in `BENCHMARK_PROTOCOL.md`).
+6. **Learning hygiene** — no held-out sets in current fits; `policy_targets.csv` lacks era
+   tagging (Phase 7 validator).
+
+## 6. Non-negotiables carried over from the master prompt
+
+- Correctness → reproducibility → measurement validity → strength → performance, in that order.
+- Every phase has an exit gate; failed gates stop progression and get the smallest
+  distinguishing experiment.
+- Experiments recorded in `EXPERIMENT_LOG.md` when run, with the full reproducibility block.
+- No default escapes: no "train longer / add a variant / tweak five hyperparameters" responses
+  to a failed gate (master prompt §20 list applies verbatim).
+- Champion changes only via the gate (`mcts_lab.promote` / gated nightly path) — unchanged
+  from root `CLAUDE.md`.
+- Layer-experiment conclusions from before the maxⁿ fix stay invalid until re-measured.

--- a/docs/agent-strength-rebuild/phases/PHASE_0_FREEZE.md
+++ b/docs/agent-strength-rebuild/phases/PHASE_0_FREEZE.md
@@ -1,0 +1,72 @@
+# Phase 0 — Freeze and Preserve the Current System
+
+- **Purpose:** stop uncontrolled training from generating further misleading/era-mixed data;
+  preserve current champions, datasets, and performance records for comparison and forensics.
+
+- **Work completed:**
+  - Removed the `schedule:` cron trigger (`0 */6 * * *`) from
+    `.github/workflows/nightly-mcts-training.yml`; kept `workflow_dispatch` with its full input
+    surface for deliberate, attended runs (decision D-003).
+  - Inventoried and sha256-pinned all durable assets at baseline commit `cabe2dd`
+    (`../DATA_LINEAGE.md`): 3 data corpora, serving registry, champion/latest state,
+    gen140 checkpoint, ratings DB, 3 learned-weight files, pre-fix archive.
+  - Labeled legacy-data compatibility (Verified / Suspect / Incompatible / Unknown) and set the
+    rule that the new Phase 6–8 loop never loads legacy corpora by default.
+  - Recorded current known performance as EXP-000 (`../EXPERIMENT_LOG.md`).
+  - Audited other automation: `.claude/commands/run-overnight-mcts.md` is manual-only and
+    already promotion-guarded (always `--dry-run` promote) — no change needed. No other
+    workflows, crontabs, or unattended runners exist.
+
+- **Components changed:** `.github/workflows/nightly-mcts-training.yml` (triggers only — job
+  steps untouched).
+
+- **Tests added:** none required (no behavioral code changed). Regression evidence:
+  `python -m mcts_lab.checks` passes; workflow YAML parses; `workflow_dispatch` retained.
+
+- **Experiments run:** EXP-000 (baseline snapshot, no new games).
+
+- **Results:**
+  - Disabled automation inventory: nightly cron (was every 6 h, ~4 runs/day, `contents: write`,
+    committing `data/*.csv`, `training/state/`, reports back to `main`). This was the only
+    scheduled job.
+  - Checkpoint inventory: champion gen140 (`training/state/champion.json`,
+    `training/state/checkpoints/champion_gen140.json`) + serving registry v2
+    (`data/champion_registry.json`) — all git-committed and hash-pinned; no copying needed,
+    git history is the immutable archive.
+  - Current benchmark snapshot: champion gen140 Elo 1388.55, TrueSkill μ 54.39 σ 5.02,
+    generation 179, 6 290 games, last promotion 2026-07-02 (details in EXP-000).
+  - Legacy compatibility table: see `../DATA_LINEAGE.md`.
+
+- **Unexpected findings:** none in this phase (audit findings are Phase 1's report).
+
+- **Gate criteria:**
+  1. No uncontrolled training process remains active.
+  2. Existing assets preserved/pinned.
+  3. New experiments cannot silently consume legacy data.
+
+- **Gate result:** **PARTIAL — BLOCKED.**
+  Criteria 2 and 3 are met (hash-pinned assets; lineage rules in force for all rescue work).
+  Criterion 1 is met in this branch but **GitHub evaluates cron schedules from the default
+  branch**, so scheduled runs continue until this change merges to `main`. The gate flips to
+  PASS on merge with no further action; any corpus/ratings drift on `main` between the baseline
+  commit and the merge is detectable against the `DATA_LINEAGE.md` hashes and must be noted
+  there after merge.
+
+- **Remaining risks:** delayed merge extends the drift window; a manually dispatched run would
+  also append to corpora (acceptable — dispatch is deliberate and attended by definition).
+
+- **Decision:** D-003 (freeze method) in `../DECISIONS.md`.
+
+- **Next phase:** Phase 1 (forensic audit) — completed in the same session; see
+  `PHASE_1_FORENSIC_AUDIT.md`.
+
+- **Reproduction commands:**
+  ```bash
+  git show 166c33b --stat                 # docs-only checkpoint
+  python -c "import yaml; wf = yaml.safe_load(open('.github/workflows/nightly-mcts-training.yml')); print(list(wf[True].keys()) if True in wf else list(wf['on'].keys()))"
+  sha256sum data/*.csv training/state/champion.json   # vs ../DATA_LINEAGE.md
+  python -m mcts_lab.checks
+  ```
+
+- **Artifacts:** `../DATA_LINEAGE.md` (frozen-asset inventory), `../EXPERIMENT_LOG.md`
+  (EXP-000), the workflow diff in this commit.

--- a/docs/agent-strength-rebuild/phases/PHASE_1_FORENSIC_AUDIT.md
+++ b/docs/agent-strength-rebuild/phases/PHASE_1_FORENSIC_AUDIT.md
@@ -1,0 +1,105 @@
+# Phase 1 — Forensic Audit
+
+- **Purpose:** determine what causes the plateau (champion frozen at gen140, 39-generation
+  promotion drought), map the full state-to-result pipeline, classify component trust, and
+  decide the repository strategy — before any implementation work.
+
+- **Work completed:** full-repo exploration at baseline commit `cabe2dd`; component trust
+  classification (`../AUDIT_INVENTORY.md`); data compatibility report (`../DATA_LINEAGE.md`);
+  repo-strategy decision (D-001); risk ranking below.
+
+## Pipeline trace (implementation owner for every step)
+
+| Step | Owner |
+|---|---|
+| Game state | `engine/board.py` (grid + bitboard, incremental frontier), `engine/game.py` |
+| Legal moves | `engine/move_generator.py::get_legal_moves` (frontier+bitboard fast path; naive+grid reference retained) |
+| Agent configuration | `agents/registry.py`, `mcts/champion_profile.py`, `training/state/champion.json` → `mcts_lab/_common.resolve_agent` |
+| Search selection | `mcts/mcts_agent.py::MCTSNode.ucb1_value` / `select_child` (UCT + optional prior/bias terms; every node maximizes the acting player) |
+| Expansion | `MCTSNode.expand` (ordered untried moves; pass-node sentinel) |
+| Evaluation / rollout | `_simulation` → rich-leaf TD / learned win-prob / rollout (`greedy_sample` default) → `_evaluate_all_players` static vector |
+| Backup | `_backpropagation` (per-player maxⁿ vector; mover-credited) |
+| Move selection | root max-visits (root-parallel merges child stats) |
+| Self-play record | `training/selfplay_core.run_arena_inproc` → snapshots (`data/champion_snapshots.csv`), TD trajectories (`data/td_trajectories.csv`), policy targets (`training/policy_selfplay.py` → `data/policy_targets.csv`) |
+| Training target → model update | `training/approaches/*` linear refits; `training/td_learning.py`; `training/policy_learning.py` (no neural net anywhere) |
+| Checkpoint | candidate JSON artifacts (`training/artifacts/candidates/`), champion checkpoints (`training/state/checkpoints/`) |
+| Candidate evaluation | `training/evaluation/{benchmark_pool,head_to_head,sequential}.py` + `analytics/tournament/arena_runner.py` |
+| Promotion / rating update | `training/evaluation/promotion_gate.py` + `analytics/tournament/gauntlet.evaluate_promotion` (6-gate) → `training/state_store.save_champion`; TrueSkill/Elo → `training/ratings_db.py` (append-only) |
+
+Every step has exactly one owner; no duplicate/diverging implementations remain in-tree (the
+July 2026 cleanup removed FastMCTS et al.; internal redundant engine paths are deliberate
+test references).
+
+## Risk-ranked findings
+
+1. **Search scaling is unproven post-fix (highest risk).** The prior audit (AUDIT_REPORT §8)
+   measured effectively depth-1 search at nightly budgets (branching factor > iteration count)
+   and fixed evaluator clamping — but no post-fix strength-vs-compute curve exists. If more
+   compute does not buy strength, every learning phase is moot. → Phase 4 mandatory gate.
+2. **Candidate generation appears exhausted.** All three roster approaches produce uniformly
+   negative deltas vs the champion (EXP-000: ΔElo −60 to −117 over 48–56 paired games each);
+   1 promotion in 41 runs. The plumbing (durable resume, SPRT, gate) audits clean — the
+   *approach family* (small linear refits over small corpora, no held-out sets) is the suspect.
+   → Phases 5–8 replace the candidate source; do not spend more compute on nightly iterations.
+3. **The objective is the wrong game.** Default scoring is the non-standard house mode
+   (+5/corner, +2/center; `engine/game.py:25-38`); the standard +5 monomino-last bonus is
+   missing from `Board.get_score` (`engine/board.py:562`) despite AUDIT_REPORT §3.8 claiming
+   scoring verified. Decided: standard scoring becomes the target (D-002). → Phase 2.
+4. **Two champion sources of truth disagree.** Training champion `gen140`
+   (`training/state/champion.json`) vs serving registry `v2 = key_findings_best`
+   (`data/champion_registry.json`, what `agents/champion.py` and the web demo load). The
+   validated champion is not what users play. → D-009 reserved; Phase 9.
+5. **Determinism leaks (avoidable, codified in `../BENCHMARK_PROTOCOL.md`):** wall-clock budget
+   mode; env flags read at import time (`engine/move_generator.py:63-88`); tree-parallel mode's
+   documented races; within-game persistence of history/NST tables. Iteration budgets +
+   single-thread gate games + fixed seeds neutralize all of these today.
+6. **Learning hygiene gaps:** no held-out evaluation in any current fit; `policy_targets.csv`
+   has no era/budget column (teacher rows mixed with old near-random 40 ms rows);
+   `champion_snapshots.csv` is era-mixed. → Phase 7 validator + fresh manifested datasets.
+7. **Minor:** Zobrist hash recomputed from scratch per call (perf only);
+   `docs/00-overview/DOCUMENTATION_INDEX.md` dead links (hygiene);
+   Elo pairwise decomposition in a 4-player game is a known approximation (TrueSkill already
+   primary).
+
+## Audit-hypothesis verdicts (from the governing master prompt §1)
+
+| Hypothesis | Verdict |
+|---|---|
+| Backprop credit to wrong player | **Was real, fixed 2026-07-01** (commit `732bd9c`); regression suite `tests/test_maxn_backprop.py`; pre-fix data quarantined by era cutoffs |
+| Workers not receiving intended config | Not observed; root-parallel workers get pickled board + derived seeds + full config (`mcts/parallel.py`); config-extraction test exists |
+| Training data mixed across incompatible configs | **Partially real** — see risks 6; era tags exist for TD rows only |
+| Multiple diverging MCTS implementations | No longer — single implementation since July 2026 cleanup |
+| Expensive deep rollouts, little information | Plausible, unmeasured post-fix → Phase 5 |
+| Large branching → shallow search / starved children | **Confirmed pre-fix at nightly budgets** (AUDIT_REPORT §8); post-fix magnitude unknown → Phase 4 |
+| Compute not translating to strength | Unknown — the central question → Phase 4 gate |
+| Elo over-trusted in a multiplayer, non-transitive setting | Mitigated (TrueSkill-primary, Wilson CIs, SPRT) but matchup-matrix retention/non-transitivity monitoring incomplete → Phase 9 |
+
+- **Components changed:** none (audit only).
+- **Tests added:** none.
+- **Experiments run:** EXP-000 (baseline snapshot).
+- **Unexpected findings:** missing monomino bonus contradicting AUDIT_REPORT §3.8; serving vs
+  training champion split; policy_targets era-blindness.
+
+- **Gate criteria:** every loop component has an identified owner and data path; major
+  correctness risks documented; repository strategy explicitly decided; next phase can proceed
+  without depending on unknown legacy behavior.
+- **Gate result:** **PASS.**
+
+- **Remaining risks:** risks 1–6 above are open by design — they are the work of Phases 2–9,
+  now scheduled with explicit gates rather than unknowns.
+- **Decision:** D-001 (stay in this repo), D-002 (standard scoring), D-003 (freeze), D-004
+  (branch naming); open decisions D-005…D-011 reserved in `../DECISIONS.md`.
+- **Next phase:** Phase 2 — trusted engine (standard scoring first; exact task list in
+  `../HANDOFF.md`).
+
+- **Reproduction commands:**
+  ```bash
+  python -m mcts_lab.checks
+  python -m pytest tests/test_maxn_backprop.py tests/test_move_generation_equivalence.py tests/test_legality_bitboard_equivalence.py -q
+  python - <<'EOF'
+  import json; s=json.load(open('training/state/latest.json'))
+  print(s['generation'], s['total_games'], s['last_promoted_generation'])
+  EOF
+  ```
+- **Artifacts:** `../AUDIT_INVENTORY.md`, `../DATA_LINEAGE.md`, `../DECISIONS.md`,
+  `../EXPERIMENT_LOG.md` (EXP-000).


### PR DESCRIPTION
## What this is

Session 1 of the agent-strength rescue governed by the master prompt: the mandatory documentation-only planning checkpoint, the Phase 0 freeze of uncontrolled training, and the Phase 1 forensic audit. **No engine, search, or training code changes** — three commits:

1. `docs: establish agent-strength rescue master plan` — new `docs/agent-strength-rebuild/` directory (MASTER_PLAN, AUDIT_INVENTORY, DECISIONS, BENCHMARK_PROTOCOL, DATA_LINEAGE with sha256 pins at baseline commit `cabe2dd`, EXPERIMENT_LOG with the EXP-000 baseline, CURRENT_STATUS, HANDOFF) + one index line in `docs/README.md`.
2. `ops: freeze nightly training cron (Phase 0)` — removes the every-6-hours `schedule:` trigger from `nightly-mcts-training.yml`; `workflow_dispatch` and all job steps are untouched.
3. `docs: Phase 1 forensic audit report` — pipeline trace, risk-ranked findings, audit-hypothesis verdicts.

## ⚠️ The freeze activates on merge, not before

GitHub evaluates cron schedules from the **default branch**. Until this PR merges, the nightly job keeps running every 6 hours and appending to `data/*.csv` and `training/state/` on `main`. Phase 0's gate is recorded as PARTIAL — BLOCKED for exactly this reason; it flips to PASS the moment this merges. Merging promptly minimizes drift from the hash-pinned baseline.

## Decisions recorded (details in `docs/agent-strength-rebuild/DECISIONS.md`)

- **D-001** — stay in this repository (single validated engine + search, strong eval infra, one-directional UI coupling); revisit if Phase 6 model work makes serving coupling painful.
- **D-002** — **Standard Blokus scoring is the target ruleset** (owner decision). The engine currently defaults to house scoring (+5/corner, +2/center) and the standard +5 monomino-last bonus is missing from `Board.get_score` — implementing it is the first Phase 2 task.
- **D-003** — freeze method: drop cron, keep `workflow_dispatch` for deliberate runs.
- **D-004** — all rescue work develops on this harness-designated branch rather than per-phase branches.

## Key audit findings (full report: `docs/agent-strength-rebuild/phases/PHASE_1_FORENSIC_AUDIT.md`)

1. Search scaling is unproven post-maxⁿ-fix — Phase 4 is the critical gate before any learning work.
2. The candidate approach family looks exhausted: all three roster approaches are consistently −60 to −117 Elo vs the champion; 1 promotion in 41 runs. The plumbing audits clean.
3. Two champion sources of truth disagree: training `gen140` vs serving registry `v2` (the web demo does not serve the validated champion).
4. Learning-hygiene gaps: no held-out sets; `policy_targets.csv` mixes teacher-budget and old near-random rows with no era column.

## Verification

- `python -m mcts_lab.checks` — all 7 checks pass after the changes.
- Workflow YAML parses; only trigger left is `workflow_dispatch`.
- Commit 1 verified docs-only via `git show --stat`.
- Asset hashes in `DATA_LINEAGE.md` reproducible via `sha256sum data/*.csv training/state/champion.json …`.

## Next (separate PR)

Phase 2 task 1 per `HANDOFF.md`: implement the monomino-last bonus, make `SCORING_MODE_STANDARD` the default for new evaluation, with unit tests; then property tests and the full-game reference↔optimized differential harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8)_