### PR TITLE
docs: record Phase 0 gate PASS after nightly freeze merged

### DIFF
--- a/docs/agent-strength-rebuild/CURRENT_STATUS.md
+++ b/docs/agent-strength-rebuild/CURRENT_STATUS.md
@@ -8,14 +8,14 @@ _Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 
   after the documentation-only checkpoint commit.
 - **Current phase gate:**
   - Phase 0: no uncontrolled training scheduled; assets pinned; legacy data labeled.
-    Status: **PARTIAL — BLOCKED on merge** (cron removal only takes effect on `main`; see
-    `phases/PHASE_0_FREEZE.md`).
+    Status: **PASS** — PR #190 merged (`ea68caf`), the freeze is live on `main`, and no
+    nightly run fired in the drift window (see `phases/PHASE_0_FREEZE.md`).
   - Phase 1: pipeline mapped, risks ranked, repo strategy decided. Status: **PASS**
     (see `phases/PHASE_1_FORENSIC_AUDIT.md`).
 - **Most recent validated result:** EXP-000 baseline — champion gen140, Elo 1388.55,
   TrueSkill μ 54.39 σ 5.02; 39-generation promotion drought; all current candidates negative
   vs champion (`EXPERIMENT_LOG.md`).
-- **Current blockers:** PR merge required to activate the nightly freeze on `main`.
+- **Current blockers:** none.
 - **Session objective:** documentation-only master-plan checkpoint → Phase 0 freeze →
   Phase 1 audit report. No engine/search/training code changes.
 - **Files changed this session:** `docs/agent-strength-rebuild/**` (new),
@@ -24,7 +24,7 @@ _Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 
 - **Experiments planned/run:** EXP-000 (baseline snapshot, no new games).
 - **Tests added:** none (docs + workflow-trigger change only). `python -m mcts_lab.checks`
   re-run as regression evidence.
-- **Gate status summary:** Phase 0 PARTIAL — BLOCKED (merge); Phase 1 PASS.
+- **Gate status summary:** Phase 0 PASS (post-merge); Phase 1 PASS.
 - **Next recommended task:** Phase 2 — implement standard scoring (+5 monomino-last bonus,
   `SCORING_MODE_STANDARD` default for new evaluation) with unit tests, then the property-test
   suite and full-game reference↔optimized differential harness. See `HANDOFF.md`.

--- a/docs/agent-strength-rebuild/HANDOFF.md
+++ b/docs/agent-strength-rebuild/HANDOFF.md
@@ -6,12 +6,10 @@ _For the next agent/session. Read `MASTER_PLAN.md`, `CURRENT_STATUS.md`, `DECISI
 ## Where things stand (after session 1, 2026-07-12)
 
 - The governing plan, audit, decisions, protocol, and lineage docs all live in this directory.
-- Phase 0: cron trigger removed from `.github/workflows/nightly-mcts-training.yml`
-  (`workflow_dispatch` kept). **Not effective until the PR merges to `main`** — until then the
-  6-hourly nightly job keeps running and appending to `data/*.csv` + `training/state/`.
-  If the merge is delayed, expect drift from the `DATA_LINEAGE.md` hashes (baseline commit
-  `cabe2dd` is the authoritative pin).
-- Phase 1: audit complete — `AUDIT_INVENTORY.md` + `phases/PHASE_1_FORENSIC_AUDIT.md`.
+- Phase 0: **complete and live** — PR #190 merged (`ea68caf`); the nightly cron is removed on
+  `main` (`workflow_dispatch` kept) and no nightly run fired between baseline `cabe2dd` and
+  the merge, so the `DATA_LINEAGE.md` hashes remain exact. Gate: PASS.
+- Phase 1: audit complete — `AUDIT_INVENTORY.md` + `phases/PHASE_1_FORENSIC_AUDIT.md`. Gate: PASS.
 - Decisions taken: stay in this repo (D-001); **standard Blokus scoring is the target ruleset**
   (D-002, explicit user decision); freeze method (D-003); branch naming (D-004).
 
@@ -51,8 +49,7 @@ sha256sum data/*.csv training/state/champion.json   # compare against DATA_LINEA
 3. **Dual champion registries** (`training/state/champion.json` gen140 vs
    `data/champion_registry.json` v2) — serving champion is not the validated training champion.
    Decision D-009 reserved for Phase 9; do not "fix" this casually, the web demo depends on it.
-4. Nightly job may still run until merge (see above).
-5. `docs/00-overview/DOCUMENTATION_INDEX.md` has dead links (hygiene debt only).
+4. `docs/00-overview/DOCUMENTATION_INDEX.md` has dead links (hygiene debt only).
 
 ## Session protocol reminders
 

--- a/docs/agent-strength-rebuild/phases/PHASE_0_FREEZE.md
+++ b/docs/agent-strength-rebuild/phases/PHASE_0_FREEZE.md
@@ -44,16 +44,17 @@
   2. Existing assets preserved/pinned.
   3. New experiments cannot silently consume legacy data.
 
-- **Gate result:** **PARTIAL — BLOCKED.**
-  Criteria 2 and 3 are met (hash-pinned assets; lineage rules in force for all rescue work).
-  Criterion 1 is met in this branch but **GitHub evaluates cron schedules from the default
-  branch**, so scheduled runs continue until this change merges to `main`. The gate flips to
-  PASS on merge with no further action; any corpus/ratings drift on `main` between the baseline
-  commit and the merge is detectable against the `DATA_LINEAGE.md` hashes and must be noted
-  there after merge.
+- **Gate result:** **PASS** (updated 2026-07-12 after PR #190 merged as `ea68caf`).
+  Criteria 2 and 3 were met at commit time (hash-pinned assets; lineage rules in force).
+  Criterion 1 became effective on merge: GitHub evaluates cron schedules from the default
+  branch, and `main` now carries the workflow with `workflow_dispatch` as its only trigger.
+  **Drift check:** the only commits on `main` between baseline `cabe2dd` and the merge are this
+  PR's own three commits — no nightly run fired in the window, so the `DATA_LINEAGE.md` hashes
+  remain exact for the state on `main`.
+  _(Gate was recorded as PARTIAL — BLOCKED between commit and merge, per the original text.)_
 
-- **Remaining risks:** delayed merge extends the drift window; a manually dispatched run would
-  also append to corpora (acceptable — dispatch is deliberate and attended by definition).
+- **Remaining risks:** a manually dispatched run would still append to corpora (acceptable —
+  dispatch is deliberate and attended by definition).
 
 - **Decision:** D-003 (freeze method) in `../DECISIONS.md`.
 


### PR DESCRIPTION
Follow-up bookkeeping to #190, which merged as `ea68caf` and activated the Phase 0 nightly-training freeze on `main`.

Docs-only, three files in `docs/agent-strength-rebuild/`:

- **`phases/PHASE_0_FREEZE.md`** — gate flipped from PARTIAL — BLOCKED to **PASS**, with the post-merge drift check recorded: the only commits on `main` between baseline `cabe2dd` and the merge were #190's own, so no nightly run fired in the window and the `DATA_LINEAGE.md` sha256 pins remain exact for the state on `main`.
- **`CURRENT_STATUS.md`** — Phase 0 gate PASS, blocker cleared.
- **`HANDOFF.md`** — merge caveat removed; next action unchanged (Phase 2, task 1: standard scoring with the monomino-last bonus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8)_