### PR TITLE
Phase 2 task 1: standard Blokus scoring — monomino-last bonus, standard by default

### DIFF
--- a/analytics/tournament/arena_runner.py
+++ b/analytics/tournament/arena_runner.py
@@ -31,7 +31,7 @@ from analytics.winprob.features import (
     extract_player_snapshot_features,
 )
 from engine.board import Player
-from engine.game import BlokusGame
+from engine.game import SCORING_MODE_STANDARD, VALID_SCORING_MODES, BlokusGame
 from engine.move_generator import LegalMoveGenerator, Move
 from engine.pieces import PieceGenerator
 from mcts.champion_profile import CHALLENGE_CHAMPION_PROFILE, build_mcts_kwargs, load_challenge_champion_profile
@@ -159,6 +159,9 @@ class RunConfig:
     max_turns: int = DEFAULT_MAX_TURNS
     notes: str = ""
     snapshots: SnapshotConfig = field(default_factory=SnapshotConfig)
+    # Scoring objective for arena games. Standard is the evaluation target
+    # (decision D-002); "house" is explicit opt-in for historical comparisons.
+    scoring_mode: str = SCORING_MODE_STANDARD
 
     @classmethod
     def from_dict(cls, config: Mapping[str, Any]) -> RunConfig:
@@ -179,6 +182,7 @@ class RunConfig:
         if not isinstance(snapshots_raw, Mapping):
             raise ValueError("RunConfig 'snapshots' must be an object when provided.")
         snapshots = SnapshotConfig.from_dict(snapshots_raw)
+        scoring_mode = str(config.get("scoring_mode", SCORING_MODE_STANDARD))
         run_config = cls(
             agents=agents,
             num_games=num_games,
@@ -188,6 +192,7 @@ class RunConfig:
             max_turns=max_turns,
             notes=notes,
             snapshots=snapshots,
+            scoring_mode=scoring_mode,
         )
         run_config.validate()
         return run_config
@@ -207,6 +212,11 @@ class RunConfig:
             )
         if self.max_turns <= 0:
             raise ValueError("max_turns must be > 0.")
+        if self.scoring_mode not in VALID_SCORING_MODES:
+            raise ValueError(
+                f"Unsupported scoring_mode '{self.scoring_mode}'. "
+                f"Expected one of {sorted(VALID_SCORING_MODES)}."
+            )
         self.snapshots.validate()
 
     def to_dict(self) -> Dict[str, Any]:
@@ -219,6 +229,7 @@ class RunConfig:
             "max_turns": self.max_turns,
             "notes": self.notes,
             "snapshots": self.snapshots.to_dict(),
+            "scoring_mode": self.scoring_mode,
         }
 
     @property
@@ -698,7 +709,7 @@ def run_single_game(
         for agent_name in set(seat_assignment.values())
     }
 
-    game = BlokusGame()
+    game = BlokusGame(scoring_mode=run_config.scoring_mode)
     move_generator = LegalMoveGenerator()
     passes = 0
     invalid_actions = 0

--- a/browser_python/worker_bridge.py
+++ b/browser_python/worker_bridge.py
@@ -33,7 +33,7 @@ _VALID_SCORING_MODES = ("standard", "house")
 class WebWorkerGameBridge:
     def __init__(self):
         self.game = BlokusGame()
-        self.scoring_mode = "house"
+        self.scoring_mode = "standard"
         self.agents = {}
         self.players_config = []
         self.mcts_top_moves = []
@@ -111,8 +111,8 @@ class WebWorkerGameBridge:
             return BlokusGame()
 
     def init_game(self, config_dict: Dict[str, Any]):
-        raw_mode = str(config_dict.get("scoring_mode") or "house").lower()
-        self.scoring_mode = raw_mode if raw_mode in _VALID_SCORING_MODES else "house"
+        raw_mode = str(config_dict.get("scoring_mode") or "standard").lower()
+        self.scoring_mode = raw_mode if raw_mode in _VALID_SCORING_MODES else "standard"
         self.game = self._new_game()
         # Convert config_dict to native Python objects to avoid Pyodide proxy destruction issues
         self.players_config = []

--- a/docs/agent-strength-rebuild/BENCHMARK_PROTOCOL.md
+++ b/docs/agent-strength-rebuild/BENCHMARK_PROTOCOL.md
@@ -1,10 +1,18 @@
 # Benchmark Protocol
 
-**Protocol version:** `rescue_v1` (2026-07-12). Any change to pool, seeds, budgets, seat policy,
+**Protocol version:** `rescue_v2` (2026-07-12). Any change to pool, seeds, budgets, seat policy,
 or scoring mode requires a version bump recorded here and referenced in every experiment entry.
 Raw match outcomes and matchup matrices are the primary evidence; every rating is a summary.
 
-## Fixed conditions (rescue_v1)
+**Version history:**
+- `rescue_v2` (2026-07-12) — scoring mode is **`SCORING_MODE_STANDARD`** (coverage + 15
+  all-pieces + 5 monomino-last), now the engine/arena default (D-002 implemented). All
+  pre-`rescue_v2` results — including every rating in `training/state/ratings.sqlite` and the
+  gen140 champion numbers — are **house-scored and not directly comparable**; standard-scored
+  baselines are re-anchored by the first `rescue_v2` evaluation runs.
+- `rescue_v1` (2026-07-12) — initial codification; house scoring (historical engine default).
+
+## Fixed conditions (rescue_v2)
 
 | Condition | Value | Source |
 |---|---|---|
@@ -12,7 +20,7 @@ Raw match outcomes and matchup matrices are the primary evidence; every rating i
 | Seeds | `20260620, 20260621` (nightly convention); pool defaults `20260101, 20260202` where the code requires them | `mcts_lab/eval.py`, `benchmark_pool.py` |
 | Seat policy | `round_robin` (required — cancels first-move advantage deterministically; `randomized` allowed only for exploratory runs, never gates) | `analytics/tournament/arena_runner.py` |
 | Move budget | **Iteration-deterministic** (`deterministic_time_budget` + `iterations_per_ms`), never wall-clock, for anything feeding a gate | `mcts/search_profiles.py`, repo convention |
-| Scoring mode | house (historical) until Phase 2 lands standard scoring; then `SCORING_MODE_STANDARD` and protocol bumps to `rescue_v2` | D-002 |
+| Scoring mode | `SCORING_MODE_STANDARD` (engine, arena `RunConfig`, and TD self-play default; house is explicit opt-in via `RunConfig.scoring_mode`) | D-002, implemented 2026-07-12 |
 | Minimum games | screen ≥ 20; confirmation ≥ 60; SPRT cap 160 paired games/candidate | `promotion_gate.py`, `sequential.py` |
 | Statistics | Wilson 95% CI on win rate; TrueSkill (PlackettLuce) μ/σ, conservative = μ−3σ; Wald SPRT α=β=0.05; paired permutation test | existing implementations |
 | Hardware note | record runner class (GitHub-hosted 2-core vs local) in every experiment entry | — |

--- a/docs/agent-strength-rebuild/CURRENT_STATUS.md
+++ b/docs/agent-strength-rebuild/CURRENT_STATUS.md
@@ -2,6 +2,36 @@
 
 _Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 / master prompt §3)._
 
+## Session 2026-07-12 (session 2 — Phase 2 task 1: standard scoring)
+
+- **Current phase:** Phase 2 (trusted engine), task 1 of 3 complete.
+- **Current phase gate:** reference↔optimized agreement at scale + property tests + versioned
+  formats — **open** (tasks 2–3 pending). Task 1 (standard scoring) done.
+- **Work completed:** +5 monomino-last bonus implemented (`Board.player_last_piece`, set in
+  `place_piece`, copied in `Board.copy`, applied in `get_score` when all 21 pieces used);
+  scoring defaults flipped to `SCORING_MODE_STANDARD` in `BlokusGame`, arena `RunConfig`
+  (new field, validated, persisted in run configs), `training/td_selfplay.py`,
+  `browser_python/worker_bridge.py`, and the `GameState` schema. House mode remains explicit
+  opt-in. Benchmark protocol bumped to `rescue_v2`; scoring-era boundary recorded in
+  `DATA_LINEAGE.md`.
+- **Tests added:** `tests/test_standard_scoring.py` (11 tests: bonus combinations, last-piece
+  tracking, copy independence, mode defaults, RunConfig round-trip/validation);
+  `test_house_scoring_is_default` → `test_standard_scoring_is_default`.
+- **Tests passing:** new suite 11/11; `test_engine` + `test_game_result` +
+  `test_champion_serving_scoring` + `test_pass_turn` 60/60; `test_maxn_backprop` +
+  `test_tactical_positions` 8/8; `test_arena_play_quality` + `test_audit_invariants` +
+  `test_agent_interface_contract` 35/35; `mcts_lab.checks` 7/7. End-to-end seeded arena run
+  verified (`scoring_mode: standard` persisted; identical outcomes on repeated same-seed runs).
+- **Tests failing:** none.
+- **Known accepted edge (verified):** the transposition table caches only feature-based
+  evaluator results — no cached value depends on `get_score` — except terminal-state rewards
+  under deterministic-eval configs, where the Zobrist hash (set-based piece tracking) cannot
+  distinguish which piece was last. Requires all 21 pieces used + identical grid via different
+  move order inside one search: negligible; revisit only if Phase 3 node-stats show anomalies.
+- **Next recommended task:** Phase 2 task 2 — property-test suite + full-game
+  reference↔optimized differential harness (see `HANDOFF.md`).
+
+
 ## Session 2026-07-12 (session 1 — plan, freeze, audit)
 
 - **Current phase:** Phase 0 (freeze) + Phase 1 (forensic audit), executed together this session

--- a/docs/agent-strength-rebuild/DATA_LINEAGE.md
+++ b/docs/agent-strength-rebuild/DATA_LINEAGE.md
@@ -18,6 +18,7 @@ Rules and inventory for every dataset and model artifact. Governing rules:
 | maxⁿ backprop fix | `DEBUGGED_BACKPROP_EPOCH_RUN_ID = 20260701T204805Z` (gen 139, commit `732bd9c`) | Anything earlier used the cooperating-opponents search — invalid for strength conclusions |
 | Multi-agent framework | `MULTI_AGENT_EPOCH_RUN_ID = 20260626T055723Z` | Reporting-era cutoff for approach comparisons |
 | Rescue baseline | commit `cabe2dd7738daca661798d422ee487179640e34f` (2026-07-12) | All hashes below pinned at this commit |
+| Standard-scoring switch | Phase 2 task 1 commit (2026-07-12, protocol `rescue_v2`) | Arena results, ratings rows, and self-play `final_score` labels produced **before** this commit are house-scored; everything after defaults to standard scoring (+5 monomino-last implemented). Never mix across this boundary |
 
 ## Frozen-asset inventory (sha256 @ rescue baseline)
 
@@ -30,8 +31,8 @@ state).
 
 | File | sha256 | Compatibility |
 |---|---|---|
-| `champion_snapshots.csv` (~1.5k rows, per-ply Layer-6/se_* features + outcome labels) | `ad5322ee34e7e2cb01a4fb28cd5614677814ca0125db8e1bfd71f0f1451ebcdd` | **Suspect** — era-mixed accumulation; post-fix rows not separable without join on run metadata; usable only for legacy `heuristic_tune` refits |
-| `td_trajectories.csv` (~2.1k rows, 45 `f_*`/`nf_*` features, `agent_version`, `feature_set_version=rich_blokus_v1`) | `e46c81461f7f48254dc06d087b2be8cd957e571cf850a8a1ca9d501cddd69cad` | **Verified-tagged** — rows carry generating agent/budget tags; filterable by era |
+| `champion_snapshots.csv` (~1.5k rows, per-ply Layer-6/se_* features + outcome labels) | `ad5322ee34e7e2cb01a4fb28cd5614677814ca0125db8e1bfd71f0f1451ebcdd` | **Suspect** — era-mixed accumulation; post-fix rows not separable without join on run metadata; usable only for legacy `heuristic_tune` refits; all existing `final_score` labels are house-scored |
+| `td_trajectories.csv` (~2.1k rows, 45 `f_*`/`nf_*` features, `agent_version`, `feature_set_version=rich_blokus_v1`) | `e46c81461f7f48254dc06d087b2be8cd957e571cf850a8a1ca9d501cddd69cad` | **Verified-tagged** — rows carry generating agent/budget tags; filterable by era; all existing reward/score labels are house-scored (rows appended post-`rescue_v2` are standard-scored) |
 | `policy_targets.csv` (~75k rows, root visit counts, grouped by `decision_id`) | `e420bf0ffde2c62a7172536d5db3c45e9d80a87f2202cfabf93df0117af305e0` | **Suspect** — no era/agent column; collection spans budgets (old 40 ms near-random rows + teacher rows indistinguishable) |
 | `champion_registry.json` (serving registry, `current_version: v2`) | `561a45fa4fb737fb424555faf4f729945f6878a501c7fb13781700d5c536f6c4` | **Verified** as serving state; lineage split from training champion (D-009) |
 | `layer6_calibrated_weights.json` | `412231ffc0c49a26ac54089e7dd2812bc67d2b36eceedb47cd883ff3511207d3` | **Verified** artifact |

--- a/docs/agent-strength-rebuild/DECISIONS.md
+++ b/docs/agent-strength-rebuild/DECISIONS.md
@@ -39,6 +39,10 @@ Format per governing master prompt §21. Statuses: Proposed / Accepted / Superse
 - **Decision:** **Standard Blokus scoring** is the training/evaluation objective. Phase 2
   implements the monomino-last bonus and makes `SCORING_MODE_STANDARD` the default for all new
   evaluation. House mode remains available for historical comparability only.
+- **Implemented:** 2026-07-12 (Phase 2 task 1) — `Board.player_last_piece` + the +5 bonus in
+  `Board.get_score`; `BlokusGame`, arena `RunConfig`, TD self-play, browser worker, and API
+  schema defaults flipped to standard; protocol bumped to `rescue_v2`. Tests:
+  `tests/test_standard_scoring.py`.
 - **Consequences:** historical arena results (house-scored) are not directly comparable to
   post-Phase-2 results; benchmark baselines must be re-anchored under standard scoring
   (recorded in `BENCHMARK_PROTOCOL.md` as a protocol version bump when it happens).

--- a/docs/agent-strength-rebuild/HANDOFF.md
+++ b/docs/agent-strength-rebuild/HANDOFF.md
@@ -15,20 +15,21 @@ _For the next agent/session. Read `MASTER_PLAN.md`, `CURRENT_STATUS.md`, `DECISI
 
 ## Exact next action
 
-**Phase 2, task 1:** implement standard scoring correctly.
+**Phase 2, task 2** (task 1 — standard scoring — is DONE, 2026-07-12, protocol `rescue_v2`):
 
-1. Add the +5 monomino-last bonus to scoring (standard mode). Today `Board.get_score`
-   (`engine/board.py:562`) only has coverage + 15 all-pieces; `engine/game.py:25-38` defines
-   `SCORING_MODE_STANDARD`/`HOUSE` with house as default. The bonus needs "last piece played
-   was the monomino" state — check what `game_history` already records before adding board
-   state.
-2. Unit tests: all four bonus combinations (none / +15 / +5 / +20), both scoring modes,
-   ranking/`GameResult` under standard mode.
-3. Make standard mode the default for `mcts_lab.eval` / benchmark runs; bump
-   `BENCHMARK_PROTOCOL.md` to `rescue_v2` in the same commit; house mode stays available.
-4. Then: property-test suite (consider `hypothesis` — new dev dependency, record a decision)
-   and the full-game reference↔optimized differential harness
-   (naive movegen + grid legality vs frontier + bitboard, thousands of positions).
+1. Property-test suite for the engine invariants (occupancy monotonicity, piece-inventory
+   conservation incl. `player_last_piece`, turn order, clone independence, serialization
+   round-trip, terminal-implies-no-moves). Consider `hypothesis` — new dev dependency, record
+   a decision in `DECISIONS.md` either way.
+2. Full-game reference↔optimized differential harness: naive movegen + grid legality vs
+   frontier + bitboard across thousands of randomized positions/trajectories (legal moves,
+   resulting states, inventories, current player, terminal status, scores, rankings).
+3. Version the state/action formats (schema id surfaced in self-play records) — Phase 2 task 3.
+
+Notes from task 1: the browser bundle (`frontend/public/blokus_core.zip`) is generated — the
+next `scripts/build_browser_core.sh` run picks up the engine change automatically; do not edit
+`browser_python/` module copies. The Zobrist/TT terminal-state edge for the monomino bonus is
+documented in `CURRENT_STATUS.md` (accepted, negligible).
 
 ## Commands to reproduce current results
 

--- a/engine/board.py
+++ b/engine/board.py
@@ -26,6 +26,10 @@ class Player(Enum):
 # Pre-computed player list to avoid repeated list(Player) allocations
 _PLAYERS = list(Player)
 
+# Piece id of the 1-square monomino (== pieces.PieceType.MONOMINO.value; kept as a
+# literal so board.py stays independent of the piece catalogue).
+MONOMINO_PIECE_ID = 1
+
 
 @dataclass
 class Position:
@@ -60,6 +64,9 @@ class Board:
             Player.GREEN: Position(self.SIZE - 1, 0),
         }
         self.player_pieces_used = {player: set() for player in Player}
+        # Last piece id each player placed (None until their first placement).
+        # Needed for standard Blokus scoring: +5 if the monomino was played last.
+        self.player_last_piece: Dict[Player, Optional[int]] = dict.fromkeys(Player)
         self.player_first_move = dict.fromkeys(Player, True)
         self.game_over = False
         self.current_player = Player.RED
@@ -541,6 +548,7 @@ class Board:
 
         # Record the piece as used
         self.player_pieces_used[player].add(piece_id)
+        self.player_last_piece[player] = piece_id
 
         # Mark first move as completed
         self.player_first_move[player] = False
@@ -561,11 +569,13 @@ class Board:
 
     def get_score(self, player: Player) -> int:
         """
-        Calculate score for a player.
-        
+        Calculate score for a player (standard Blokus base scoring).
+
         Score is based on:
         - Number of squares covered by pieces
-        - Bonus for using all pieces
+        - +15 bonus for using all 21 pieces
+        - +5 additional bonus if all pieces were used AND the monomino was the
+          last piece placed (standard Blokus rule)
         """
         # Count squares covered by player
         squares_covered = np.sum(self.grid == player.value)
@@ -573,6 +583,8 @@ class Board:
         # Bonus for using all pieces (21 pieces total)
         if len(self.player_pieces_used[player]) == 21:
             squares_covered += 15  # Bonus for using all pieces
+            if self.player_last_piece[player] == MONOMINO_PIECE_ID:
+                squares_covered += 5  # Monomino-played-last bonus
 
         return squares_covered
 
@@ -649,6 +661,7 @@ class Board:
         new_board = object.__new__(Board)
         new_board.grid = self.grid.copy()
         new_board.player_pieces_used = {k: v.copy() for k, v in self.player_pieces_used.items()}
+        new_board.player_last_piece = self.player_last_piece.copy()
         new_board.player_first_move = self.player_first_move.copy()
         new_board.game_over = self.game_over
         new_board.current_player = self.current_player

--- a/engine/game.py
+++ b/engine/game.py
@@ -24,14 +24,14 @@ logger = logging.getLogger(__name__)
 
 # Scoring modes.
 #
-#   "standard" — standard Blokus scoring only: 1 point per covered square plus
-#                the +15 all-pieces bonus (see Board.get_score). No positional
-#                bonuses. This is the mode intended for public "Play the
-#                Champion" play.
+#   "standard" — standard Blokus scoring only: 1 point per covered square, +15
+#                for using all pieces, +5 more if the monomino was played last
+#                (see Board.get_score). No positional bonuses. This is the
+#                DEFAULT and the training/evaluation objective (decision D-002).
 #   "house"    — the project's historical house scoring: standard scoring PLUS
 #                non-standard corner-control (+5/corner) and center-control
-#                (+2/center square) bonuses. This is the default to preserve the
-#                behavior of all prior arena runs and experiments.
+#                (+2/center square) bonuses. Explicit opt-in only; kept for
+#                comparability with pre-2026-07 arena runs and experiments.
 SCORING_MODE_STANDARD = "standard"
 SCORING_MODE_HOUSE = "house"
 VALID_SCORING_MODES = (SCORING_MODE_STANDARD, SCORING_MODE_HOUSE)
@@ -63,7 +63,7 @@ class BlokusGame:
         self,
         enable_telemetry: bool = True,
         telemetry_fast_mode: bool = True,
-        scoring_mode: str = SCORING_MODE_HOUSE,
+        scoring_mode: str = SCORING_MODE_STANDARD,
     ):
         self.board = Board()
         self.move_generator = get_shared_generator()
@@ -77,9 +77,11 @@ class BlokusGame:
                 f"Invalid scoring_mode {scoring_mode!r}. "
                 f"Valid modes: {', '.join(VALID_SCORING_MODES)}."
             )
-        # Default is "house" to preserve historical behavior for all existing
-        # arena runs and experiments, which construct BlokusGame() with no
-        # explicit scoring_mode. Public play opts into "standard" explicitly.
+        # Default is "standard" — the target ruleset for training, evaluation,
+        # and public play (agent-strength rescue decision D-002, 2026-07-12).
+        # House mode remains available for historical comparability and must be
+        # requested explicitly. Results scored under different modes are not
+        # comparable (BENCHMARK_PROTOCOL.md).
         self.scoring_mode = scoring_mode
 
     def make_move(self, move: Move, player: Optional[Player] = None) -> bool:

--- a/schemas/game_state.py
+++ b/schemas/game_state.py
@@ -93,7 +93,7 @@ class GameState(BaseModel):
     game_over: bool
     winner: Optional[Player] = None
     scoring_mode: ScoringMode = Field(
-        default=ScoringMode.HOUSE,
+        default=ScoringMode.STANDARD,
         description="Scoring rule set in effect for this game ('standard' or 'house')",
     )
     legal_moves: List[Move] = Field(description="Available legal moves for current player")

--- a/tests/test_champion_serving_scoring.py
+++ b/tests/test_champion_serving_scoring.py
@@ -351,10 +351,10 @@ def test_house_scoring_includes_positional_bonuses():
     assert game.get_score(Player.RED) == base + bonus
 
 
-def test_house_scoring_is_default():
-    # Existing arena runs / experiments construct BlokusGame() with no mode and
-    # must keep the historical house behavior.
-    assert BlokusGame().scoring_mode == "house"
+def test_standard_scoring_is_default():
+    # Standard Blokus is the training/evaluation objective (rescue decision
+    # D-002); house scoring is explicit opt-in for historical comparisons.
+    assert BlokusGame().scoring_mode == "standard"
 
 
 def test_standard_and_house_diverge_on_same_position():

--- a/tests/test_standard_scoring.py
+++ b/tests/test_standard_scoring.py
@@ -1,0 +1,110 @@
+"""
+Standard Blokus scoring: the +5 monomino-played-last bonus and the
+standard-by-default scoring mode (agent-strength rescue decision D-002).
+"""
+
+import pytest
+
+from analytics.tournament.arena_runner import RunConfig
+from engine.board import MONOMINO_PIECE_ID, Board, Player, Position
+from engine.game import (
+    SCORING_MODE_HOUSE,
+    SCORING_MODE_STANDARD,
+    BlokusGame,
+)
+
+
+def _mark_all_pieces_used(board: Board, player: Player, last_piece_id: int) -> None:
+    """Simulate a finished inventory: all 21 pieces used, given piece last."""
+    for piece_id in range(1, 22):
+        board.player_pieces_used[player].add(piece_id)
+    board.player_last_piece[player] = last_piece_id
+
+
+class TestMonominoLastBonus:
+    def test_all_pieces_with_monomino_last_gets_plus_twenty(self):
+        board = Board()
+        board.place_piece([Position(0, 0)], Player.RED, MONOMINO_PIECE_ID)
+        _mark_all_pieces_used(board, Player.RED, MONOMINO_PIECE_ID)
+        # 1 covered square + 15 all-pieces + 5 monomino-last
+        assert board.get_score(Player.RED) == 1 + 15 + 5
+
+    def test_all_pieces_with_other_piece_last_gets_plus_fifteen(self):
+        board = Board()
+        board.place_piece([Position(0, 0), Position(0, 1)], Player.RED, 2)
+        _mark_all_pieces_used(board, Player.RED, last_piece_id=2)
+        assert board.get_score(Player.RED) == 2 + 15
+
+    def test_monomino_last_without_all_pieces_gets_no_bonus(self):
+        board = Board()
+        board.place_piece([Position(0, 0)], Player.RED, MONOMINO_PIECE_ID)
+        assert board.player_last_piece[Player.RED] == MONOMINO_PIECE_ID
+        assert board.get_score(Player.RED) == 1
+
+    def test_no_pieces_played_scores_zero(self):
+        board = Board()
+        assert board.player_last_piece[Player.RED] is None
+        assert board.get_score(Player.RED) == 0
+
+    def test_last_piece_tracks_most_recent_placement(self):
+        board = Board()
+        board.place_piece([Position(0, 0)], Player.RED, MONOMINO_PIECE_ID)
+        board.place_piece([Position(1, 1), Position(1, 2)], Player.RED, 2)
+        assert board.player_last_piece[Player.RED] == 2
+        # Other players unaffected
+        assert board.player_last_piece[Player.BLUE] is None
+
+    def test_board_copy_preserves_last_piece(self):
+        board = Board()
+        board.place_piece([Position(0, 0)], Player.RED, MONOMINO_PIECE_ID)
+        clone = board.copy()
+        assert clone.player_last_piece[Player.RED] == MONOMINO_PIECE_ID
+        # Copies must be independent (corner-adjacent continuation, legal)
+        assert clone.place_piece([Position(1, 1), Position(1, 2)], Player.RED, 2)
+        assert clone.player_last_piece[Player.RED] == 2
+        assert board.player_last_piece[Player.RED] == MONOMINO_PIECE_ID
+
+    def test_bonus_applies_in_both_scoring_modes(self):
+        # The monomino bonus is part of the BASE score, so house mode
+        # (standard + positional bonuses) includes it too.
+        for mode in (SCORING_MODE_STANDARD, SCORING_MODE_HOUSE):
+            game = BlokusGame(scoring_mode=mode, enable_telemetry=False)
+            board = game.board
+            board.place_piece([Position(0, 0)], Player.RED, MONOMINO_PIECE_ID)
+            _mark_all_pieces_used(board, Player.RED, MONOMINO_PIECE_ID)
+            without_bonus = board.get_score(Player.RED) - 5
+            board.player_last_piece[Player.RED] = 2
+            assert board.get_score(Player.RED) == without_bonus
+
+
+class TestScoringModeDefaults:
+    def test_blokus_game_defaults_to_standard(self):
+        assert BlokusGame(enable_telemetry=False).scoring_mode == SCORING_MODE_STANDARD
+
+    def test_run_config_defaults_to_standard(self):
+        config = RunConfig.from_dict(_minimal_run_config_dict())
+        assert config.scoring_mode == SCORING_MODE_STANDARD
+
+    def test_run_config_round_trips_scoring_mode(self):
+        raw = _minimal_run_config_dict()
+        raw["scoring_mode"] = SCORING_MODE_HOUSE
+        config = RunConfig.from_dict(raw)
+        assert config.scoring_mode == SCORING_MODE_HOUSE
+        assert RunConfig.from_dict(config.to_dict()).scoring_mode == SCORING_MODE_HOUSE
+
+    def test_run_config_rejects_invalid_scoring_mode(self):
+        raw = _minimal_run_config_dict()
+        raw["scoring_mode"] = "tournament"
+        with pytest.raises(ValueError, match="scoring_mode"):
+            RunConfig.from_dict(raw)
+
+
+def _minimal_run_config_dict() -> dict:
+    return {
+        "agents": [
+            {"name": f"random_{i}", "type": "random", "params": {}}
+            for i in range(4)
+        ],
+        "num_games": 1,
+        "seed": 20260620,
+    }

--- a/tests/test_training_report_guardrails.py
+++ b/tests/test_training_report_guardrails.py
@@ -64,7 +64,7 @@ def test_verify_fails_when_state_missing(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 2. Exactly one scheduled training workflow
+# 2. No scheduled training workflow (Phase 0 freeze)
 # ---------------------------------------------------------------------------
 
 def _scheduled_workflows():
@@ -77,11 +77,17 @@ def _scheduled_workflows():
             scheduled.append(os.path.basename(path))
     return scheduled
 
-def test_exactly_one_scheduled_workflow():
+def test_no_scheduled_training_workflow():
+    # Phase 0 of the agent-strength rescue removed the nightly cron (decision
+    # D-003, docs/agent-strength-rebuild/): scheduled training stays frozen
+    # until a Phase 7+ gate earns it back. Training runs are manual
+    # (workflow_dispatch) only; zero schedules also still guarantees two
+    # workflows cannot both train + email.
     scheduled = _scheduled_workflows()
-    assert scheduled == ["nightly-mcts-training.yml"], (
-        "Exactly one scheduled (cron) training workflow must exist so two "
-        f"workflows cannot both train + email. Found: {scheduled}"
+    assert scheduled == [], (
+        "No scheduled (cron) training workflow may exist while the Phase 0 "
+        "freeze is in force (DECISIONS.md D-003 revisit conditions). "
+        f"Found: {scheduled}"
     )
 
 

--- a/training/td_selfplay.py
+++ b/training/td_selfplay.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from analytics.tournament.arena_runner import AgentConfig, build_agent
 from engine.board import Player
-from engine.game import BlokusGame
+from engine.game import SCORING_MODE_STANDARD, BlokusGame
 from training.rich_features import (
     FeatureCache,
     board_occupancy,
@@ -145,7 +145,9 @@ def play_game(
         if capture_agents is None or name in set(capture_agents)
     }
 
-    game = BlokusGame()
+    # Standard scoring is the training objective (D-002); final_scores recorded
+    # below label the TD trajectories, so the mode must match evaluation.
+    game = BlokusGame(scoring_mode=SCORING_MODE_STANDARD)
     traj = GameTrajectory(game_id=game_id, seed=seed, seat_agent=seat_agent)
     for p in _PLAYERS:
         traj.decisions[p.value] = []

--- a/webapi/app.py
+++ b/webapi/app.py
@@ -981,7 +981,7 @@ class GameManager:
             move_count=game.get_move_count(),
             game_over=game.is_game_over(),
             winner=self._convert_player_back(game.winner) if game.winner else None,
-            scoring_mode=game_data.get('scoring_mode', ScoringMode.HOUSE),
+            scoring_mode=game_data.get('scoring_mode', ScoringMode.STANDARD),
             legal_moves=legal_moves,
             created_at=game_data['created_at'],
             updated_at=game_data['updated_at'],


### PR DESCRIPTION
Implements rescue decision **D-002** (standard Blokus is the training/evaluation objective) — the first Phase 2 work item from `docs/agent-strength-rebuild/HANDOFF.md`.

## What changed

**Engine (`engine/board.py`, `engine/game.py`)**
- `Board` now tracks `player_last_piece` (set in `place_piece`, preserved by `Board.copy()` — the MCTS hot clone path).
- `Board.get_score` implements the standard rule that was missing: when all 21 pieces are used, +15, **plus +5 if the monomino was the last piece placed**. The bonus lives in the base score, so MCTS rollout reward deltas optimize the real objective, in both modes.
- `BlokusGame` defaults to `SCORING_MODE_STANDARD`. House scoring (+5/corner, +2/center) remains fully supported as explicit opt-in (the webapi research profile still selects it explicitly).

**Mode plumbing**
- Arena `RunConfig` gains a validated `scoring_mode` field (default standard) that is persisted in `run_config.json`/`summary.json` and passed to the game loop — previously arenas silently used house scoring with no way to choose.
- `training/td_selfplay.py` labels, `browser_python/worker_bridge.py` default, `schemas/game_state.py` `GameState` default, and the `webapi/app.py` inline fallback all follow suit.

**Tests**
- New `tests/test_standard_scoring.py` (11 tests): all bonus combinations (+0/+15/+20), last-piece tracking, copy independence, engine/RunConfig defaults, round-trip, invalid-mode rejection.
- `test_house_scoring_is_default` → `test_standard_scoring_is_default`.
- `test_exactly_one_scheduled_workflow` → `test_no_scheduled_training_workflow`: this guardrail had been failing on `main` since the Phase 0 cron removal merged (#190); it now asserts zero scheduled workflows, protecting the freeze itself.

**Docs (same PR per repo convention)**
- `BENCHMARK_PROTOCOL.md` bumped to **`rescue_v2`**: all pre-bump ratings (including the gen140 champion's Elo/TrueSkill numbers) are house-scored and not directly comparable; standard baselines re-anchor with the first `rescue_v2` runs.
- `DATA_LINEAGE.md`: scoring-era boundary recorded; existing corpus `final_score` labels marked house-scored.
- `CURRENT_STATUS.md` / `HANDOFF.md` / `DECISIONS.md` updated (D-002 marked implemented).

## Verification

- Full suite: **733 passed, 1 skipped** (725+1-fix from the parallel run, plus the 8-test guardrail file re-run green; the single failure was the pre-existing scheduled-workflow guardrail, fixed here).
- `python -m mcts_lab.checks`: 7/7.
- End-to-end seeded arena (`mcts_lab.eval`, 2 games): plays through, `scoring_mode: standard` persisted in the run config and summary, and repeated same-seed runs produce identical final scores (determinism preserved through the new `Board` field).

## Notes

- The browser bundle (`frontend/public/blokus_core.zip`) is generated by `scripts/build_browser_core.sh`; the next bundle build/deploy picks up the engine change automatically.
- Known accepted edge (verified & documented in `CURRENT_STATUS.md`): the transposition table caches only feature-based evaluator results, so no cached value depends on `get_score` — except terminal states under deterministic-eval configs, where the set-based Zobrist hash can't distinguish which piece was last. Requires all 21 pieces + identical grids via different move orders inside one search; negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8)_