### PR TITLE
Phase 2 task 2: engine property invariants + full-game reference↔optimized differential harness

### DIFF
--- a/docs/agent-strength-rebuild/CURRENT_STATUS.md
+++ b/docs/agent-strength-rebuild/CURRENT_STATUS.md
@@ -2,6 +2,32 @@
 
 _Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 / master prompt §3)._
 
+## Session 2026-07-12 (session 3 — Phase 2 task 2: property tests + differential harness)
+
+- **Current phase:** Phase 2 (trusted engine), tasks 1–2 of 3 complete.
+- **Current phase gate:** reference↔optimized agreement at scale ✔ (this session) + property
+  tests ✔ + versioned state/action formats (task 3, open).
+- **Work completed:**
+  - `tests/test_engine_properties.py` — seeded full-game invariant suite (every ply of 3 full
+    games): occupancy monotonicity, piece-inventory conservation incl. `player_last_piece`,
+    strict turn rotation, grid↔bitboard duality + pairwise-disjoint player masks, independent
+    score recomputation, terminal-implies-no-moves, deep clone independence, same-seed
+    reproducibility (decision D-012: hand-rolled seeded loops, no hypothesis).
+  - `tests/test_engine_differential.py` — full-game reference↔optimized harness: naive
+    full-scan movegen + grid legality vs frontier movegen + bitboard legality, cross-checked
+    every ply (mover move-set equality; all four players on a stride; legality agreement on
+    sampled legal + perturbed placements; pass-detection equality; terminal scores incl. the
+    standard bonuses recomputed from the raw grid). Scales via `BLOKUS_DIFF_GAMES`.
+- **Tests passing:** properties 4/4 (2 s); differential 1/1 at default 3-game scale (14 s,
+  ≥240 move-set + ≥300 legality checks asserted) and at 20-game scale (94 s, ≥1 600 move-set +
+  ≥2 000 legality checks) — zero disagreements. `mcts_lab.checks` 7/7.
+- **Tests failing:** none.
+- **Note for task 3:** a board serialization **round-trip test is not possible yet** — the
+  engine has no board deserializer (only `grid.tolist()` snapshots). It lands with the
+  versioned state/action formats in task 3.
+- **Next recommended task:** Phase 2 task 3 — versioned state/action schema surfaced in
+  self-play records + serialization round-trip; then the Phase 2 gate report.
+
 ## Session 2026-07-12 (session 2 — Phase 2 task 1: standard scoring)
 
 - **Current phase:** Phase 2 (trusted engine), task 1 of 3 complete.

--- a/docs/agent-strength-rebuild/DECISIONS.md
+++ b/docs/agent-strength-rebuild/DECISIONS.md
@@ -79,6 +79,25 @@ Format per governing master prompt §21. Statuses: Proposed / Accepted / Superse
   branch names.
 - **Related:** session protocol in `CURRENT_STATUS.md`.
 
+## D-012 — Property tests: hand-rolled seeded invariant loops, no hypothesis (for now)
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Context:** Phase 2 task 2 requires property/invariant tests. The master plan flagged
+  `hypothesis` as a candidate tool; the repo has no property-testing framework and its existing
+  invariant suites (`tests/test_frontier_basic.py`, `tests/test_bitboard_basic.py`) are
+  hand-rolled loops over seeded random self-play.
+- **Options considered:** adopt `hypothesis` (shrinking, broader input distribution, new dev
+  dependency + CI cost); extend the existing hand-rolled seeded-trajectory pattern.
+- **Decision:** hand-rolled seeded full-game invariant loops
+  (`tests/test_engine_properties.py`), consistent with the repo's existing pattern; every ply
+  of real games is checked, seeds are fixed, failures reproduce exactly.
+- **Consequences:** no automatic input shrinking; coverage is bounded by the seeded
+  trajectories rather than adversarial generation.
+- **Revisit conditions:** an engine bug slips past these suites, or Phase 2 differential
+  testing needs adversarial position generation the trajectories don't reach.
+- **Related:** Phase 2 in `MASTER_PLAN.md`; `tests/test_engine_differential.py`.
+
 ---
 
 ## Open decisions (required before their phases)

--- a/docs/agent-strength-rebuild/HANDOFF.md
+++ b/docs/agent-strength-rebuild/HANDOFF.md
@@ -15,21 +15,23 @@ _For the next agent/session. Read `MASTER_PLAN.md`, `CURRENT_STATUS.md`, `DECISI
 
 ## Exact next action
 
-**Phase 2, task 2** (task 1 — standard scoring — is DONE, 2026-07-12, protocol `rescue_v2`):
+**Phase 2, task 3** (tasks 1–2 DONE 2026-07-12: standard scoring + protocol `rescue_v2`;
+property suite `tests/test_engine_properties.py` + differential harness
+`tests/test_engine_differential.py`, zero disagreements at 20-game scale):
 
-1. Property-test suite for the engine invariants (occupancy monotonicity, piece-inventory
-   conservation incl. `player_last_piece`, turn order, clone independence, serialization
-   round-trip, terminal-implies-no-moves). Consider `hypothesis` — new dev dependency, record
-   a decision in `DECISIONS.md` either way.
-2. Full-game reference↔optimized differential harness: naive movegen + grid legality vs
-   frontier + bitboard across thousands of randomized positions/trajectories (legal moves,
-   resulting states, inventories, current player, terminal status, scores, rankings).
-3. Version the state/action formats (schema id surfaced in self-play records) — Phase 2 task 3.
+1. Version the state/action formats: a schema id for board state + move encoding, surfaced in
+   self-play records (`analytics/tournament/arena_runner.py` game records /
+   `training/td_selfplay.py` trajectories) so Phase 7 datasets can declare provenance.
+2. Board serialization round-trip: the engine currently has **no board deserializer** (only
+   `grid.tolist()` snapshots) — add serialize/deserialize with a round-trip property test
+   (this was the one Phase 2 invariant that could not be tested in task 2).
+3. Then write `phases/PHASE_2_TRUSTED_ENGINE.md` with the gate verdict (needs: differential
+   agreement ✔, property invariants ✔, standard scoring tested ✔, versioned formats — task 3).
 
-Notes from task 1: the browser bundle (`frontend/public/blokus_core.zip`) is generated — the
-next `scripts/build_browser_core.sh` run picks up the engine change automatically; do not edit
-`browser_python/` module copies. The Zobrist/TT terminal-state edge for the monomino bonus is
-documented in `CURRENT_STATUS.md` (accepted, negligible).
+Notes: browser bundle (`frontend/public/blokus_core.zip`) is generated — next
+`scripts/build_browser_core.sh` run picks up engine changes; never edit `browser_python/`
+module copies. Zobrist/TT terminal-state edge documented in `CURRENT_STATUS.md` (accepted).
+Differential harness scales with `BLOKUS_DIFF_GAMES` (default 3; 20 ≈ 94 s).
 
 ## Commands to reproduce current results
 

--- a/tests/test_engine_differential.py
+++ b/tests/test_engine_differential.py
@@ -1,0 +1,159 @@
+"""
+Full-game differential harness: reference engine paths vs optimized engine
+paths (agent-strength rescue, Phase 2 task 2).
+
+Reference implementation (per docs/agent-strength-rebuild/MASTER_PLAN.md
+Phase 2): naive full-board-scan move generation + grid-based legality.
+Optimized implementation: frontier-based move generation + bitboard legality
+(the production path).
+
+Seeded full games are driven by the OPTIMIZED path; at every ply the harness
+cross-checks the two implementations on legal-move sets and placement
+legality. Scale with BLOKUS_DIFF_GAMES (default 3 games ≈ 900+ position
+checks; 20 games ≈ 6000+ checks were verified once when this suite landed).
+"""
+
+import os
+import random
+
+import numpy as np
+
+from engine.board import Board, Player, _PLAYERS
+from engine.move_generator import LegalMoveGenerator
+
+NUM_GAMES = int(os.environ.get("BLOKUS_DIFF_GAMES", "3"))
+BASE_SEED = 20260620
+# Full four-player move-set comparison is naive-generation-heavy; do it on a
+# stride so default CI runs stay fast while every ply still checks the mover.
+ALL_PLAYER_STRIDE = 10
+
+
+def _move_positions(generator, move):
+    return move.get_positions(generator.piece_orientations_cache[move.piece_id])
+
+
+def _move_key(generator, move):
+    """Coordinate-canonical key so orientation indices don't matter."""
+    positions = _move_positions(generator, move)
+    return (move.piece_id, tuple(sorted((p.row, p.col) for p in positions)))
+
+
+def _move_sets_equal(generator, board, player):
+    naive = {_move_key(generator, m)
+             for m in generator._get_legal_moves_naive(board, player)}
+    frontier = {_move_key(generator, m)
+                for m in generator._get_legal_moves_frontier(board, player)}
+    return naive, frontier
+
+
+def _legality_agrees(generator, board, player, move):
+    positions = _move_positions(generator, move)
+    grid_ok = board.can_place_piece(positions, player)
+    coords = [(p.row, p.col) for p in positions]
+    bitboard_ok = generator.is_placement_legal_bitboard_coords(
+        board, player, coords, is_first_move=board.player_first_move[player]
+    )
+    return grid_ok == bitboard_ok, grid_ok, bitboard_ok
+
+
+class TestFullGameDifferential:
+    def test_reference_and_optimized_agree_across_full_games(self):
+        generator = LegalMoveGenerator()
+        positions_checked = 0
+        legality_checked = 0
+
+        for game_index in range(NUM_GAMES):
+            seed = BASE_SEED + game_index
+            rng = random.Random(seed)
+            board = Board()
+            ply = 0
+            consecutive_passes = 0
+
+            while consecutive_passes < len(_PLAYERS):
+                player = board.current_player
+
+                # Move-set equivalence for the player about to act (every ply)
+                # and for ALL players on a stride.
+                players_to_check = (
+                    list(Player) if ply % ALL_PLAYER_STRIDE == 0 else [player]
+                )
+                for p in players_to_check:
+                    naive, frontier = _move_sets_equal(generator, board, p)
+                    assert naive == frontier, (
+                        f"seed {seed} ply {ply}: naive vs frontier move sets "
+                        f"differ for {p.name}: only-naive="
+                        f"{sorted(naive - frontier)[:3]} only-frontier="
+                        f"{sorted(frontier - naive)[:3]}"
+                    )
+                    positions_checked += 1
+
+                # Pass-detection equivalence for the mover.
+                frontier_moves = generator.get_legal_moves(board, player)
+                assert bool(frontier_moves) == generator.has_legal_moves(board, player)
+
+                if not frontier_moves:
+                    board._update_current_player()
+                    consecutive_passes += 1
+                    continue
+                consecutive_passes = 0
+
+                # Legality equivalence: a sample of legal moves plus perturbed
+                # (mostly illegal) variants must agree between grid and
+                # bitboard checkers.
+                for move in rng.sample(frontier_moves, min(3, len(frontier_moves))):
+                    agrees, grid_ok, bb_ok = _legality_agrees(
+                        generator, board, player, move
+                    )
+                    assert agrees and grid_ok and bb_ok, (
+                        f"seed {seed} ply {ply}: legality mismatch on generated "
+                        f"move {move} (grid={grid_ok}, bitboard={bb_ok})"
+                    )
+                    legality_checked += 1
+
+                    shifted = type(move)(
+                        move.piece_id,
+                        move.orientation,
+                        min(move.anchor_row + 1, Board.SIZE - 1),
+                        move.anchor_col,
+                    )
+                    try:
+                        agrees, grid_ok, bb_ok = _legality_agrees(
+                            generator, board, player, shifted
+                        )
+                    except (IndexError, KeyError):
+                        continue  # perturbation fell off the board entirely
+                    assert agrees, (
+                        f"seed {seed} ply {ply}: legality mismatch on perturbed "
+                        f"move {shifted} (grid={grid_ok}, bitboard={bb_ok})"
+                    )
+                    legality_checked += 1
+
+                move = rng.choice(frontier_moves)
+                orientations = generator.piece_orientations_cache[move.piece_id]
+                assert board.place_piece(
+                    move.get_positions(orientations), player, move.piece_id
+                )
+                ply += 1
+
+            # Terminal cross-checks: both paths agree nobody can move, and the
+            # final scores recomputed from the grid match get_score.
+            for p in Player:
+                assert generator._get_legal_moves_naive(board, p) == []
+                assert not generator.has_legal_moves(board, p)
+                base = int(np.count_nonzero(board.grid == p.value))
+                expected = base
+                if len(board.player_pieces_used[p]) == 21:
+                    expected += 15
+                    if board.player_last_piece[p] == 1:  # monomino
+                        expected += 5
+                assert board.get_score(p) == expected
+
+            assert ply >= 20, f"seed {seed}: degenerate game ({ply} plies)"
+
+        # The harness must actually have exercised a meaningful sample.
+        assert positions_checked >= NUM_GAMES * 80, (
+            f"only {positions_checked} move-set comparisons ran"
+        )
+        assert legality_checked >= NUM_GAMES * 100, (
+            f"only {legality_checked} legality comparisons ran"
+        )

--- a/tests/test_engine_properties.py
+++ b/tests/test_engine_properties.py
@@ -1,0 +1,199 @@
+"""
+Engine property/invariant tests over seeded random full-game trajectories
+(agent-strength rescue, Phase 2 task 2).
+
+Style follows the repo's existing hand-rolled invariant suites
+(tests/test_frontier_basic.py, tests/test_bitboard_basic.py): play real games
+with fixed seeds through the PRODUCTION move-generation path and assert the
+invariants at every ply. No property-testing framework (see DECISIONS.md).
+"""
+
+import random
+
+import numpy as np
+
+from engine.board import Board, Player, _PLAYERS
+from engine.move_generator import LegalMoveGenerator
+
+SEEDS = [20260620, 20260621, 20260622]
+
+
+def _play_full_game(seed, ply_callback=None):
+    """Play one full seeded game via the production (frontier) move path.
+
+    Calls ply_callback(board, player, move, positions, pre_state) after every
+    successful placement. Returns the terminal board and the ply count.
+    """
+    rng = random.Random(seed)
+    board = Board()
+    generator = LegalMoveGenerator()
+    plies = 0
+    consecutive_passes = 0
+
+    while consecutive_passes < len(_PLAYERS):
+        player = board.current_player
+        moves = generator.get_legal_moves(board, player)
+        if not moves:
+            board._update_current_player()
+            consecutive_passes += 1
+            continue
+        consecutive_passes = 0
+        move = rng.choice(moves)
+        orientations = generator.piece_orientations_cache[move.piece_id]
+        positions = move.get_positions(orientations)
+
+        pre_state = _capture_state(board)
+        assert board.place_piece(positions, player, move.piece_id), (
+            f"seed {seed}: generated move was rejected by place_piece: {move}"
+        )
+        plies += 1
+        if ply_callback is not None:
+            ply_callback(board, player, move, positions, pre_state)
+
+    return board, plies
+
+
+def _capture_state(board):
+    return {
+        "grid": board.grid.copy(),
+        "occupied": int(np.count_nonzero(board.grid)),
+        "pieces_used": {p: set(board.player_pieces_used[p]) for p in Player},
+        "last_piece": dict(board.player_last_piece),
+        "current_player": board.current_player,
+        "move_count": board.move_count,
+    }
+
+
+class TestFullGameInvariants:
+    """Invariants asserted after EVERY ply of seeded full games."""
+
+    def test_invariants_hold_across_full_games(self):
+        for seed in SEEDS:
+            checked = {"plies": 0}
+
+            def check(board, player, move, positions, pre):
+                checked["plies"] += 1
+                grid = board.grid
+
+                # Occupancy monotonicity: previously occupied cells unchanged;
+                # exactly len(positions) new cells, all owned by the mover.
+                prev = pre["grid"]
+                changed = np.argwhere(grid != prev)
+                assert len(changed) == len(positions), (
+                    f"seed {seed}: expected {len(positions)} new cells, "
+                    f"got {len(changed)}"
+                )
+                for r, c in changed:
+                    assert prev[r, c] == 0, "occupied cell was overwritten"
+                    assert grid[r, c] == player.value, "new cell owned by wrong player"
+                assert int(np.count_nonzero(grid)) == pre["occupied"] + len(positions)
+
+                # Piece-inventory conservation: used set only grows, exactly by
+                # the played piece; a used piece never returns.
+                for p in Player:
+                    before = pre["pieces_used"][p]
+                    after = board.player_pieces_used[p]
+                    if p is player:
+                        assert after == before | {move.piece_id}
+                        assert move.piece_id not in before, "piece reused"
+                    else:
+                        assert after == before, "bystander inventory changed"
+
+                # Last-piece tracking matches the placement just made.
+                assert board.player_last_piece[player] == move.piece_id
+                for p in Player:
+                    if p is not player:
+                        assert board.player_last_piece[p] == pre["last_piece"][p]
+
+                # Turn order: strict rotation; move_count increments by one.
+                expected_next = _PLAYERS[(_PLAYERS.index(player) + 1) % len(_PLAYERS)]
+                assert board.current_player == expected_next
+                assert board.move_count == pre["move_count"] + 1
+
+                # Grid/bitboard duality stays consistent; per-player bitmasks
+                # are pairwise disjoint and union to occupied_bits.
+                board.assert_bitboard_consistent()
+                union = 0
+                for p in Player:
+                    bits = board.player_bits[p]
+                    assert bits & union == 0, "two players share a square"
+                    union |= bits
+                assert union == board.occupied_bits
+
+                # Score recomputed independently from the grid matches
+                # get_score (before any completion bonuses apply).
+                if len(board.player_pieces_used[player]) < 21:
+                    assert board.get_score(player) == int(
+                        np.count_nonzero(grid == player.value)
+                    )
+
+            board, plies = _play_full_game(seed, check)
+            assert checked["plies"] == plies
+            assert plies >= 20, f"seed {seed}: game suspiciously short ({plies} plies)"
+
+    def test_terminal_state_has_no_legal_continuation(self):
+        generator = LegalMoveGenerator()
+        for seed in SEEDS:
+            board, _ = _play_full_game(seed)
+            for p in Player:
+                assert generator.get_legal_moves(board, p) == [], (
+                    f"seed {seed}: {p.name} still has moves at terminal state"
+                )
+                assert not generator.has_legal_moves(board, p)
+
+
+class TestCloneIndependence:
+    """Board.copy() must produce fully independent mutable state."""
+
+    def test_mutating_clone_leaves_original_untouched(self):
+        for seed in SEEDS:
+            # Build a midgame position, clone it, play a move on the clone.
+            rng = random.Random(seed)
+            board = Board()
+            generator = LegalMoveGenerator()
+            for _ in range(12):
+                player = board.current_player
+                moves = generator.get_legal_moves(board, player)
+                if not moves:
+                    board._update_current_player()
+                    continue
+                move = rng.choice(moves)
+                orientations = generator.piece_orientations_cache[move.piece_id]
+                board.place_piece(move.get_positions(orientations), player, move.piece_id)
+
+            snapshot = _capture_state(board)
+            frontiers_before = {p: set(board.player_frontiers[p]) for p in Player}
+            bits_before = (board.occupied_bits, {p: board.player_bits[p] for p in Player})
+
+            clone = board.copy()
+            player = clone.current_player
+            moves = generator.get_legal_moves(clone, player)
+            assert moves, f"seed {seed}: no legal move available for clone test"
+            move = rng.choice(moves)
+            orientations = generator.piece_orientations_cache[move.piece_id]
+            assert clone.place_piece(move.get_positions(orientations), player, move.piece_id)
+
+            # Original board unchanged in every mutable field.
+            assert np.array_equal(board.grid, snapshot["grid"])
+            assert {p: board.player_pieces_used[p] for p in Player} == snapshot["pieces_used"]
+            assert dict(board.player_last_piece) == snapshot["last_piece"]
+            assert board.current_player == snapshot["current_player"]
+            assert board.move_count == snapshot["move_count"]
+            assert {p: set(board.player_frontiers[p]) for p in Player} == frontiers_before
+            assert (board.occupied_bits, {p: board.player_bits[p] for p in Player}) == bits_before
+
+            # And the clone did change.
+            assert clone.move_count == snapshot["move_count"] + 1
+            assert clone.player_last_piece[player] == move.piece_id
+
+
+class TestDeterminism:
+    def test_same_seed_reproduces_identical_game(self):
+        for seed in SEEDS:
+            board_a, plies_a = _play_full_game(seed)
+            board_b, plies_b = _play_full_game(seed)
+            assert plies_a == plies_b
+            assert np.array_equal(board_a.grid, board_b.grid)
+            assert dict(board_a.player_last_piece) == dict(board_b.player_last_piece)
+            for p in Player:
+                assert board_a.get_score(p) == board_b.get_score(p)


### PR DESCRIPTION
Second Phase 2 work item from `docs/agent-strength-rebuild/HANDOFF.md`. Tests + docs only — no engine/search/training code changes.

## What's in it

**`tests/test_engine_properties.py`** — seeded full-game invariant suite, asserted at **every ply** of complete games (repo's existing hand-rolled pattern, extended; decision D-012 records choosing this over a `hypothesis` dependency):
- occupancy monotonicity (occupied cells never change owner; exactly piece-size new cells per move)
- piece-inventory conservation, including the new `player_last_piece` tracking
- strict turn rotation and move-count accounting
- grid↔bitboard duality (`assert_bitboard_consistent`) + pairwise-disjoint player bitmasks unioning to `occupied_bits`
- score recomputed independently from the raw grid matches `get_score`
- terminal-implies-no-moves for all four players
- deep clone independence (mutating a copy leaves every mutable field of the original untouched)
- same-seed games reproduce byte-identical outcomes

**`tests/test_engine_differential.py`** — the Phase 2 reference↔optimized harness. Games are driven through the **production** path (frontier movegen + bitboard legality) while the **reference** path (naive full-board scan + grid legality) is cross-checked every ply: coordinate-canonical move-set equality (mover every ply, all four players on a stride), legality agreement on sampled legal and perturbed placements, pass-detection equality, and terminal scores — including the standard +15/+5 bonuses — recomputed from the raw grid. Scales via `BLOKUS_DIFF_GAMES`.

## Verification

- Properties: 4/4 in ~2 s. Differential: default 3-game scale in ~14 s (≥240 move-set + ≥300 legality checks asserted).
- Scaled validation run: `BLOKUS_DIFF_GAMES=20` → ~6,000 cross-checks in 94 s, **zero disagreements** between reference and optimized implementations.
- Full engine test group (this + all existing engine/scoring/equivalence suites): 85/85. `mcts_lab.checks`: 7/7.

## Phase 2 status after this PR

Tasks 1–2 of 3 done. Remaining before the phase gate report: task 3 — versioned state/action formats surfaced in self-play records, plus a board serialize/deserialize API (the one invariant that couldn't be tested here: the engine has no board deserializer today, only `grid.tolist()` snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8)_