### PR TITLE
Phase 2 task 3: versioned board/move serialization + record provenance — Phase 2 gate PASS

### DIFF
--- a/analytics/tournament/arena_runner.py
+++ b/analytics/tournament/arena_runner.py
@@ -30,9 +30,9 @@ from analytics.winprob.features import (
     coerce_feature_dict,
     extract_player_snapshot_features,
 )
-from engine.board import Player
+from engine.board import STATE_SCHEMA_VERSION, Player
 from engine.game import SCORING_MODE_STANDARD, VALID_SCORING_MODES, BlokusGame
-from engine.move_generator import LegalMoveGenerator, Move
+from engine.move_generator import ACTION_SCHEMA_VERSION, LegalMoveGenerator, Move
 from engine.pieces import PieceGenerator
 from mcts.champion_profile import CHALLENGE_CHAMPION_PROFILE, build_mcts_kwargs, load_challenge_champion_profile
 from mcts.mcts_agent import MCTSAgent
@@ -962,6 +962,11 @@ def run_single_game(
         "is_valid_result": True,
         "invalid_reason": "",
         "audit_version": AUDIT_VERSION,
+        # Provenance stamps (agent-strength rescue Phase 2): which state/action
+        # encodings and scoring objective produced this game.
+        "state_schema_version": STATE_SCHEMA_VERSION,
+        "action_schema_version": ACTION_SCHEMA_VERSION,
+        "scoring_mode": run_config.scoring_mode,
     }
     return record, snapshot_rows
 

--- a/docs/agent-strength-rebuild/CURRENT_STATUS.md
+++ b/docs/agent-strength-rebuild/CURRENT_STATUS.md
@@ -2,6 +2,33 @@
 
 _Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 / master prompt §3)._
 
+## Session 2026-07-12 (session 4 — Phase 2 task 3: versioned formats + serialization) — PHASE 2 GATE: PASS
+
+- **Current phase:** Phase 2 **complete** (gate PASS — see `phases/PHASE_2_TRUSTED_ENGINE.md`);
+  next is Phase 3.
+- **Work completed:** `STATE_SCHEMA_VERSION="board_state_v1"` + `Board.to_dict()/from_dict()`
+  (authoritative fields persisted; bitboards/frontiers rebuilt from grid);
+  `ACTION_SCHEMA_VERSION="move_v1"` + `Move.to_dict()/from_dict()`; arena game records stamp
+  `state_schema_version`/`action_schema_version`/`scoring_mode` beside `audit_version`;
+  decision D-013 (TD corpus columns untouched — append-only header immutability); Phase 2 gate
+  report written.
+- **Tests added:** `tests/test_board_serialization.py` (10: full copy()-field round-trip on
+  fresh/midgame/terminal boards through real JSON, Zobrist-hash match, behavioral equivalence,
+  restored-board independence, version/malformed-payload guards, Move round-trip);
+  provenance-stamp assertions in `tests/test_arena_play_quality.py`.
+- **Tests passing:** engine group 98/98 (incl. new suites); `mcts_lab.checks` 7/7; end-to-end
+  arena run shows all three stamps in `games.jsonl`.
+- **Tests failing:** none.
+- **Unexpected finding:** live incremental frontiers hold stale entries for non-placing
+  players by design (`update_frontier_after_move` maintains only the mover's set) — harmless
+  (frontier = candidate superset, movegen re-checks legality; differential harness proves
+  move-set equality), now documented in `Board.from_dict`, which restores canonical form.
+- **Next recommended task:** Phase 3 — verify the minimal trusted search (`MCTSAgent` with all
+  experimental layers off): correctness tests on hand-authored tactical/near-terminal/
+  single-move/pass positions, deterministic seeded-search assertions on visit counts and
+  per-player Q values, and a node-statistics inspection CLI (build on `mcts/search_trace.py`).
+  Then the mandatory Phase 4 scaling gate.
+
 ## Session 2026-07-12 (session 3 — Phase 2 task 2: property tests + differential harness)
 
 - **Current phase:** Phase 2 (trusted engine), tasks 1–2 of 3 complete.

--- a/docs/agent-strength-rebuild/DECISIONS.md
+++ b/docs/agent-strength-rebuild/DECISIONS.md
@@ -98,6 +98,26 @@ Format per governing master prompt §21. Statuses: Proposed / Accepted / Superse
   testing needs adversarial position generation the trajectories don't reach.
 - **Related:** Phase 2 in `MASTER_PLAN.md`; `tests/test_engine_differential.py`.
 
+## D-013 — Engine state/action schema v1; TD corpus keeps its existing columns
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Context:** Phase 2 task 3 versions the state/action formats and surfaces them in self-play
+  records. `data/td_trajectories.csv` is an append-only corpus with a fixed header — adding a
+  column would misalign every existing row against the header, violating the DATA_LINEAGE
+  immutability rule.
+- **Decision:** `STATE_SCHEMA_VERSION = "board_state_v1"` (`engine/board.py`,
+  `Board.to_dict/from_dict`; frontiers/bitboards rebuilt from the grid on load) and
+  `ACTION_SCHEMA_VERSION = "move_v1"` (`engine/move_generator.py`, `Move.to_dict/from_dict`,
+  matching the shape already persisted by game_history/webapi/schemas). Arena game records
+  stamp both plus `scoring_mode`. The TD corpus is NOT modified — its rows already carry
+  `feature_set_version` + `agent_version` provenance; raw-state schema ids belong to the
+  Phase 7 fresh-manifest datasets.
+- **Consequences:** every new arena game is provenance-complete; the browser worker's
+  frontend-orientation remap is explicitly outside `move_v1` (documented at the constant).
+- **Revisit conditions:** Phase 7 dataset design (D-007) supersedes this for training data.
+- **Related:** `phases/PHASE_2_TRUSTED_ENGINE.md`, D-007.
+
 ---
 
 ## Open decisions (required before their phases)

--- a/docs/agent-strength-rebuild/HANDOFF.md
+++ b/docs/agent-strength-rebuild/HANDOFF.md
@@ -15,23 +15,31 @@ _For the next agent/session. Read `MASTER_PLAN.md`, `CURRENT_STATUS.md`, `DECISI
 
 ## Exact next action
 
-**Phase 2, task 3** (tasks 1–2 DONE 2026-07-12: standard scoring + protocol `rescue_v2`;
-property suite `tests/test_engine_properties.py` + differential harness
-`tests/test_engine_differential.py`, zero disagreements at 20-game scale):
+**Phase 3 — minimal trusted search** (Phase 2 is COMPLETE, gate PASS:
+`phases/PHASE_2_TRUSTED_ENGINE.md`).
 
-1. Version the state/action formats: a schema id for board state + move encoding, surfaced in
-   self-play records (`analytics/tournament/arena_runner.py` game records /
-   `training/td_selfplay.py` trajectories) so Phase 7 datasets can declare provenance.
-2. Board serialization round-trip: the engine currently has **no board deserializer** (only
-   `grid.tolist()` snapshots) — add serialize/deserialize with a round-trip property test
-   (this was the one Phase 2 invariant that could not be tested in task 2).
-3. Then write `phases/PHASE_2_TRUSTED_ENGINE.md` with the gate verdict (needs: differential
-   agreement ✔, property invariants ✔, standard scoring tested ✔, versioned formats — task 3).
+The candidate minimal search already exists: `MCTSAgent` with **all experimental layers off**
+(plain UCT + maxⁿ per-player vector backup, no tree reuse, deterministic-only TT, single
+thread, iteration budgets). Phase 3 is verification, not a rewrite:
+
+1. Search-correctness tests on hand-authored positions: near-terminal decisions with a known
+   best move (extend `tests/test_tactical_positions.py`), single-legal-move positions,
+   positions requiring passes (pass-node expansion), forced outcomes on reduced positions.
+   Assert node internals, not just the chosen move: root visit counts, per-player Q values
+   (mover-credited), terminal values, exploration behavior under fixed seeds.
+2. Node-statistics inspection CLI (build on `mcts/search_trace.py`): dump root children with
+   visits / per-player Q / prior ordering / depth histogram for any `Board.from_dict` position
+   (the new serialization API is the intended input format).
+3. Determinism matrix: same seed → identical tree stats across runs; iteration budgets only.
+4. Contingency if verification fails: a ~300-line reference MCTS for differential comparison.
+5. Then `phases/PHASE_3_MINIMAL_SEARCH.md` with the gate verdict, and on PASS proceed to the
+   **mandatory Phase 4 scaling gate** (`MASTER_PLAN.md` §4; builds on
+   `training/diagnostics/search_quality.py`).
 
 Notes: browser bundle (`frontend/public/blokus_core.zip`) is generated — next
 `scripts/build_browser_core.sh` run picks up engine changes; never edit `browser_python/`
-module copies. Zobrist/TT terminal-state edge documented in `CURRENT_STATUS.md` (accepted).
-Differential harness scales with `BLOKUS_DIFF_GAMES` (default 3; 20 ≈ 94 s).
+module copies. Zobrist/TT terminal-state edge + frontier-staleness finding documented in
+`CURRENT_STATUS.md`. Differential harness scales with `BLOKUS_DIFF_GAMES` (default 3; 20 ≈ 94 s).
 
 ## Commands to reproduce current results
 

--- a/docs/agent-strength-rebuild/phases/PHASE_2_TRUSTED_ENGINE.md
+++ b/docs/agent-strength-rebuild/phases/PHASE_2_TRUSTED_ENGINE.md
@@ -1,0 +1,82 @@
+# Phase 2 — Establish a Trusted Game Engine
+
+- **Purpose:** make the game rules an unquestionable source of truth — validated reference vs
+  optimized implementations, the correct (standard) scoring objective, invariant coverage, and
+  versioned state/action formats — before any search or learning work relies on them.
+
+- **Work completed** (three tasks, PRs #192, #193, and this one):
+  1. **Standard scoring (D-002):** `Board.player_last_piece` tracking + the missing standard
+     +5 monomino-last bonus in `Board.get_score`; `SCORING_MODE_STANDARD` made the default for
+     `BlokusGame`, arena `RunConfig` (new validated field), TD self-play, browser worker, and
+     API schema; benchmark protocol bumped to `rescue_v2`.
+  2. **Property + differential coverage:** `tests/test_engine_properties.py` (every-ply
+     invariants over seeded full games) and `tests/test_engine_differential.py` (full-game
+     reference↔optimized harness: naive full-scan movegen + grid legality vs frontier +
+     bitboard). Decision D-012: hand-rolled seeded loops, no hypothesis dependency.
+  3. **Versioned formats + serialization:** `STATE_SCHEMA_VERSION = "board_state_v1"` with
+     `Board.to_dict()/from_dict()` (authoritative fields persisted; frontiers/bitboards
+     rebuilt from the grid on load); `ACTION_SCHEMA_VERSION = "move_v1"` with
+     `Move.to_dict()/from_dict()`; arena game records now stamp
+     `state_schema_version`/`action_schema_version`/`scoring_mode` beside the existing
+     `audit_version`. Decision D-013 scopes the TD corpus out (append-only header immutability).
+
+- **Components changed:** `engine/board.py`, `engine/game.py`, `engine/move_generator.py`,
+  `analytics/tournament/arena_runner.py`, `training/td_selfplay.py`,
+  `browser_python/worker_bridge.py`, `schemas/game_state.py`, `webapi/app.py` (one default).
+
+- **Tests added:** `tests/test_standard_scoring.py` (11), `tests/test_engine_properties.py`
+  (4), `tests/test_engine_differential.py` (1 harness, ~900–6 000 cross-checks by scale),
+  `tests/test_board_serialization.py` (10), provenance assertions in
+  `tests/test_arena_play_quality.py`; guardrail repurposed to protect the Phase 0 freeze.
+
+- **Experiments run:** none (engineering phase; scaled differential validation at
+  `BLOKUS_DIFF_GAMES=20` ≈ 6 000 cross-checks, zero disagreements, 94 s).
+
+- **Results / gate criteria → evidence:**
+  | Criterion | Evidence |
+  |---|---|
+  | Reference and optimized engines agree across large randomized sets | Differential harness: move-set equality every ply, legality agreement on legal + perturbed placements, pass-detection + terminal-score equality; zero disagreements at 20-game scale (plus pre-existing equivalence suites) |
+  | No unresolved mutation/cloning defects | Every-ply invariants + deep clone-independence tests; serialization round-trip preserves all `copy()`-captured fields |
+  | Scoring is the correct (standard) target | D-002 implemented; all bonus combinations unit-tested; arena/ratings path mode-explicit |
+  | State and action formats versioned | `board_state_v1` / `move_v1` + round-trip tests + stamps in every new arena game record |
+  | Engine trusted enough to generate training data | All of the above; `mcts_lab.checks` 7/7; full engine group 98/98 |
+
+- **Unexpected findings:**
+  1. Live incremental frontiers accumulate stale entries for **non-placing** players
+     (`update_frontier_after_move` maintains only the mover's set). Harmless — frontier is a
+     candidate superset and movegen re-checks legality (differential harness proves move-set
+     equality) — but documented now in `Board.from_dict`, which restores the canonical
+     recomputed form.
+  2. (Task 1) The Zobrist hash omits `player_last_piece`; only terminal-state rewards under
+     deterministic-eval configs could ever collide. Accepted, documented in CURRENT_STATUS.
+  3. (Task 1) `AUDIT_REPORT.md` §3.8's claim that scoring was fully verified was wrong — the
+     monomino bonus was absent.
+
+- **Gate criteria:** see table above.
+- **Gate result:** **PASS.**
+
+- **Remaining risks:** frontier staleness is tolerated, not eliminated (revisit only if a
+  future consumer treats `get_frontier` as exact); house-scored historical data remains
+  quarantined per `DATA_LINEAGE.md`; browser bundle picks up engine changes only on next
+  `scripts/build_browser_core.sh` run.
+
+- **Decision:** D-002 (implemented), D-012, D-013 in `../DECISIONS.md`.
+- **Next phase:** Phase 3 — minimal trusted search verification (all-layers-off `MCTSAgent`
+  correctness tests + node-statistics inspection utility), then the mandatory Phase 4
+  search-scaling gate.
+
+- **Reproduction commands:**
+  ```bash
+  python -m pytest tests/test_engine.py tests/test_engine_properties.py \
+    tests/test_engine_differential.py tests/test_standard_scoring.py \
+    tests/test_board_serialization.py tests/test_move_generation_equivalence.py \
+    tests/test_legality_bitboard_equivalence.py tests/test_frontier_basic.py \
+    tests/test_bitboard_basic.py -q          # engine group
+  BLOKUS_DIFF_GAMES=20 python -m pytest tests/test_engine_differential.py -q  # scaled
+  python -m mcts_lab.checks
+  python -m mcts_lab.eval --agents heuristic,random --games 2 --seeds 20260620
+  # then: head -1 <run_dir>/games.jsonl | python -m json.tool | grep -E "schema|scoring"
+  ```
+
+- **Artifacts:** PRs #192/#193/this PR; test suites listed above; provenance-stamped
+  `games.jsonl` records under `training/state/selfplay_runs/`.

--- a/engine/board.py
+++ b/engine/board.py
@@ -30,6 +30,11 @@ _PLAYERS = list(Player)
 # literal so board.py stays independent of the piece catalogue).
 MONOMINO_PIECE_ID = 1
 
+# Version id of the Board.to_dict()/from_dict() state format. Bump on any
+# field/semantic change; stamped into self-play records so datasets can
+# declare which state encoding produced them (agent-strength rescue Phase 2).
+STATE_SCHEMA_VERSION = "board_state_v1"
+
 
 @dataclass
 class Position:
@@ -671,6 +676,86 @@ class Board:
         new_board.occupied_bits = self.occupied_bits
         new_board.player_bits = self.player_bits.copy()
         return new_board
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the full authoritative board state to a JSON-safe dict.
+
+        Only authoritative state is persisted (schema STATE_SCHEMA_VERSION);
+        derived caches — frontiers and bitboards — are rebuilt by from_dict.
+        Player-keyed maps use str(player.value) keys so the dict survives a
+        JSON round-trip unchanged.
+        """
+        return {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "grid": self.grid.tolist(),
+            "player_pieces_used": {
+                str(p.value): sorted(self.player_pieces_used[p]) for p in Player
+            },
+            "player_last_piece": {
+                str(p.value): self.player_last_piece[p] for p in Player
+            },
+            "player_first_move": {
+                str(p.value): bool(self.player_first_move[p]) for p in Player
+            },
+            "current_player": self.current_player.value,
+            "move_count": int(self.move_count),
+            "game_over": bool(self.game_over),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> 'Board':
+        """Reconstruct a fully independent Board from a to_dict() payload.
+
+        Raises ValueError on an unknown schema_version or malformed grid.
+
+        Frontiers are restored in canonical form (_compute_full_frontier). A
+        live board's incrementally-maintained frontier can additionally hold
+        stale entries for NON-placing players (update_frontier_after_move only
+        maintains the mover's set); consumers treat the frontier as a candidate
+        superset and re-check legality, so the two forms are behaviorally
+        equivalent (proven by tests/test_engine_differential.py move-set
+        equality and asserted by tests/test_board_serialization.py).
+        """
+        version = data.get("schema_version")
+        if version != STATE_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported board state schema {version!r}; "
+                f"expected {STATE_SCHEMA_VERSION!r}."
+            )
+        grid = np.array(data["grid"], dtype=int)
+        if grid.shape != (cls.SIZE, cls.SIZE):
+            raise ValueError(f"Board grid must be {cls.SIZE}x{cls.SIZE}; got {grid.shape}.")
+
+        board = cls()
+        board.grid = grid
+        board.player_pieces_used = {
+            p: set(data["player_pieces_used"][str(p.value)]) for p in Player
+        }
+        board.player_last_piece = {
+            p: data["player_last_piece"][str(p.value)] for p in Player
+        }
+        board.player_first_move = {
+            p: bool(data["player_first_move"][str(p.value)]) for p in Player
+        }
+        board.current_player = Player(int(data["current_player"]))
+        board.move_count = int(data["move_count"])
+        board.game_over = bool(data["game_over"])
+
+        # Rebuild derived state (bitboards + frontiers) from the grid.
+        board.occupied_bits = 0
+        board.player_bits = defaultdict(int)
+        for p in Player:
+            coords = [(int(r), int(c)) for r, c in np.argwhere(grid == p.value)]
+            mask = coords_to_mask(coords)
+            board.player_bits[p] = mask
+            board.occupied_bits |= mask
+        for p in Player:
+            if board.player_first_move[p]:
+                board.player_frontiers[p] = set()
+                board.init_frontier_for_player(p)
+            else:
+                board.player_frontiers[p] = board._compute_full_frontier(p)
+        return board
 
     def __str__(self) -> str:
         """String representation of the board."""

--- a/engine/move_generator.py
+++ b/engine/move_generator.py
@@ -87,6 +87,13 @@ DEBUG_BITBOARD = _env_flag("BLOKUS_DEBUG_BITBOARD", False)
 #            to full offsets if no legal moves are found (safe heuristic mode)
 USE_HEURISTIC_ANCHORS = _env_flag("BLOKUS_USE_HEURISTIC_ANCHORS", False)
 
+# Version id of the canonical Move encoding ({piece_id, orientation, anchor_row,
+# anchor_col}, backend orientation index). Bump on any field/semantic change;
+# stamped into self-play records (agent-strength rescue Phase 2). Note the
+# browser worker remaps orientation to a frontend index — that mapping is NOT
+# part of this schema.
+ACTION_SCHEMA_VERSION = "move_v1"
+
 
 class Move:
     """Represents a legal move in Blokus."""
@@ -102,6 +109,24 @@ class Move:
         shape = piece_orientations[self.orientation]
         positions = PiecePlacement.get_piece_positions(shape, self.anchor_row, self.anchor_col)
         return [Position(row, col) for row, col in positions]
+
+    def to_dict(self) -> dict:
+        """Canonical ACTION_SCHEMA_VERSION encoding of this move."""
+        return {
+            "piece_id": self.piece_id,
+            "orientation": self.orientation,
+            "anchor_row": self.anchor_row,
+            "anchor_col": self.anchor_col,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Move':
+        return cls(
+            int(data["piece_id"]),
+            int(data["orientation"]),
+            int(data["anchor_row"]),
+            int(data["anchor_col"]),
+        )
 
     def __str__(self):
         return f"Move(piece_id={self.piece_id}, orientation={self.orientation}, anchor=({self.anchor_row}, {self.anchor_col}))"

--- a/tests/test_arena_play_quality.py
+++ b/tests/test_arena_play_quality.py
@@ -36,6 +36,19 @@ def test_record_carries_play_quality_block():
     assert rec["moves_made"] > 0
 
 
+def test_record_carries_provenance_stamps():
+    # Agent-strength rescue Phase 2: every game record declares which
+    # state/action encodings and scoring objective produced it.
+    from engine.board import STATE_SCHEMA_VERSION
+    from engine.game import SCORING_MODE_STANDARD
+    from engine.move_generator import ACTION_SCHEMA_VERSION
+
+    rec = _run_one()
+    assert rec["state_schema_version"] == STATE_SCHEMA_VERSION
+    assert rec["action_schema_version"] == ACTION_SCHEMA_VERSION
+    assert rec["scoring_mode"] == SCORING_MODE_STANDARD  # RunConfig default
+
+
 def test_play_quality_values_are_well_formed():
     pq = _run_one()["play_quality"]
 

--- a/tests/test_board_serialization.py
+++ b/tests/test_board_serialization.py
@@ -1,0 +1,157 @@
+"""
+Versioned board/move serialization round-trip tests
+(agent-strength rescue, Phase 2 task 3).
+
+The correctness bar is the Board.copy() field set — the Zobrist hash omits
+player_last_piece/player_first_move/move_count/game_over, so hash equality is
+checked as a supplement, never as the sole criterion.
+"""
+
+import json
+import random
+
+import numpy as np
+import pytest
+
+from engine.board import STATE_SCHEMA_VERSION, Board, Player, Position
+from engine.move_generator import ACTION_SCHEMA_VERSION, LegalMoveGenerator, Move
+from mcts.zobrist import ZobristHash
+from tests.utils_game_states import generate_random_valid_state
+
+SEEDS = [20260620, 20260621, 20260622]
+
+
+def _assert_boards_equal(a: Board, restored: Board):
+    """Assert `restored` (a from_dict board) faithfully reproduces `a`.
+
+    Frontiers are compared in CANONICAL form: a live board's incremental
+    frontier may hold stale entries for non-placing players (only the mover's
+    set is maintained by update_frontier_after_move), while from_dict rebuilds
+    the clean recomputed set. Behavioral equivalence of the two forms is
+    asserted separately via legal-move-set equality.
+    """
+    assert np.array_equal(a.grid, restored.grid)
+    for p in Player:
+        assert a.player_pieces_used[p] == restored.player_pieces_used[p]
+        assert a.player_last_piece[p] == restored.player_last_piece[p]
+        assert a.player_first_move[p] == restored.player_first_move[p]
+        assert a.player_bits[p] == restored.player_bits[p]
+        if a.player_first_move[p]:
+            assert restored.player_frontiers[p] == a.player_frontiers[p]
+        else:
+            # Canonical frontier; also a subset of the (possibly stale) live one
+            # restricted to still-empty cells.
+            assert restored.player_frontiers[p] == a._compute_full_frontier(p)
+    assert a.current_player == restored.current_player
+    assert a.move_count == restored.move_count
+    assert a.game_over == restored.game_over
+    assert a.occupied_bits == restored.occupied_bits
+
+
+def _round_trip(board: Board) -> Board:
+    # Force an actual JSON round-trip so numpy scalars / non-string keys /
+    # sets would be caught, not just dict identity.
+    payload = json.loads(json.dumps(board.to_dict()))
+    return Board.from_dict(payload)
+
+
+class TestBoardRoundTrip:
+    def test_fresh_board(self):
+        _assert_boards_equal(Board(), _round_trip(Board()))
+
+    def test_midgame_boards(self):
+        for seed in SEEDS:
+            board, _ = generate_random_valid_state(num_moves=16, seed=seed)
+            restored = _round_trip(board)
+            _assert_boards_equal(board, restored)
+            restored.assert_bitboard_consistent()
+
+    def test_terminal_board(self):
+        # Play a full game (production path), then round-trip the terminal state.
+        rng = random.Random(SEEDS[0])
+        board = Board()
+        generator = LegalMoveGenerator()
+        passes = 0
+        while passes < len(Player):
+            player = board.current_player
+            moves = generator.get_legal_moves(board, player)
+            if not moves:
+                board._update_current_player()
+                passes += 1
+                continue
+            passes = 0
+            move = rng.choice(moves)
+            orientations = generator.piece_orientations_cache[move.piece_id]
+            board.place_piece(move.get_positions(orientations), player, move.piece_id)
+
+        restored = _round_trip(board)
+        _assert_boards_equal(board, restored)
+        for p in Player:
+            assert restored.get_score(p) == board.get_score(p)
+
+    def test_zobrist_hash_matches_after_round_trip(self):
+        hasher = ZobristHash(seed=42)
+        for seed in SEEDS:
+            board, _ = generate_random_valid_state(num_moves=12, seed=seed)
+            assert hasher.hash_board(board) == hasher.hash_board(_round_trip(board))
+
+    def test_behavioral_equivalence_after_round_trip(self):
+        generator = LegalMoveGenerator()
+        for seed in SEEDS:
+            board, _ = generate_random_valid_state(num_moves=14, seed=seed)
+            restored = _round_trip(board)
+            for p in Player:
+                original_moves = {
+                    (m.piece_id, m.orientation, m.anchor_row, m.anchor_col)
+                    for m in generator.get_legal_moves(board, p)
+                }
+                restored_moves = {
+                    (m.piece_id, m.orientation, m.anchor_row, m.anchor_col)
+                    for m in generator.get_legal_moves(restored, p)
+                }
+                assert original_moves == restored_moves
+                assert board.get_score(p) == restored.get_score(p)
+
+    def test_restored_board_is_independent(self):
+        board, _ = generate_random_valid_state(num_moves=10, seed=SEEDS[0])
+        restored = _round_trip(board)
+        generator = LegalMoveGenerator()
+        player = restored.current_player
+        moves = generator.get_legal_moves(restored, player)
+        assert moves
+        move = moves[0]
+        orientations = generator.piece_orientations_cache[move.piece_id]
+        snapshot_count = board.move_count
+        assert restored.place_piece(move.get_positions(orientations), player, move.piece_id)
+        assert board.move_count == snapshot_count  # original untouched
+
+    def test_schema_version_stamped_and_enforced(self):
+        payload = Board().to_dict()
+        assert payload["schema_version"] == STATE_SCHEMA_VERSION
+        payload["schema_version"] = "board_state_v0"
+        with pytest.raises(ValueError, match="schema"):
+            Board.from_dict(payload)
+
+    def test_malformed_grid_rejected(self):
+        payload = Board().to_dict()
+        payload["grid"] = [[0] * 5] * 5
+        with pytest.raises(ValueError, match="grid"):
+            Board.from_dict(payload)
+
+
+class TestMoveRoundTrip:
+    def test_move_dict_round_trip(self):
+        move = Move(piece_id=17, orientation=3, anchor_row=4, anchor_col=9)
+        payload = json.loads(json.dumps(move.to_dict()))
+        assert payload == {
+            "piece_id": 17,
+            "orientation": 3,
+            "anchor_row": 4,
+            "anchor_col": 9,
+        }
+        restored = Move.from_dict(payload)
+        assert (restored.piece_id, restored.orientation,
+                restored.anchor_row, restored.anchor_col) == (17, 3, 4, 9)
+
+    def test_action_schema_version_exists(self):
+        assert ACTION_SCHEMA_VERSION == "move_v1"


### PR DESCRIPTION
Final Phase 2 work item from `docs/agent-strength-rebuild/HANDOFF.md`. With this merged, **the Phase 2 (trusted engine) gate is PASS** — report included at `docs/agent-strength-rebuild/phases/PHASE_2_TRUSTED_ENGINE.md`.

## What changed

**Versioned board state (`engine/board.py`)** — the engine previously had no deserializer at all (the only reconstruction paths anywhere were full move-replays). New:
- `STATE_SCHEMA_VERSION = "board_state_v1"`, `Board.to_dict()` / `Board.from_dict()`. Authoritative state is persisted (grid, per-player inventories incl. `player_last_piece`, first-move flags, current player, move count, game-over); derived bitboards and frontiers are rebuilt from the grid on load. Unknown schema versions and malformed grids are rejected.

**Versioned action encoding (`engine/move_generator.py`)**
- `ACTION_SCHEMA_VERSION = "move_v1"`, `Move.to_dict()` / `Move.from_dict()` — the exact 4-field shape already persisted by `game_history`, webapi move records, and the pydantic schemas. The browser worker's frontend-orientation remap is explicitly outside this schema (documented at the constant).

**Record provenance (`analytics/tournament/arena_runner.py`)**
- Every game record in `games.jsonl` now stamps `state_schema_version`, `action_schema_version`, and `scoring_mode` beside the existing `audit_version`. Verified end-to-end in a real `mcts_lab.eval` run.
- `data/td_trajectories.csv` is deliberately **not** modified (decision **D-013**): it's an append-only corpus with a fixed header, and its rows already carry `feature_set_version` + `agent_version` provenance. Raw-state schema ids belong to the Phase 7 fresh-manifest datasets.

## Notable finding (documented, not fixed)

Live incremental frontiers accumulate stale entries for **non-placing** players — `update_frontier_after_move` maintains only the mover's set. This is behaviorally harmless (the frontier is a candidate superset; movegen re-checks legality, and the Phase 2 differential harness proves move-set equality), but it means `from_dict` restores the *canonical* recomputed frontier rather than a byte-identical copy of a live board's set. Documented in `Board.from_dict` and the round-trip tests assert canonical form + behavioral equivalence.

## Tests

- New `tests/test_board_serialization.py` (10): round-trip of every `Board.copy()`-captured field on fresh/midgame/terminal boards through actual `json.dumps`/`loads`, Zobrist-hash match, identical legal-move sets and scores on original vs restored, restored-board independence, schema-version and malformed-grid guards, `Move` round-trip.
- `tests/test_arena_play_quality.py`: provenance-stamp assertions.

## Verification

- Engine group (all engine/scoring/equivalence/property/differential/serialization suites): **98/98**.
- `mcts_lab.checks`: 7/7.
- End-to-end arena run: `games.jsonl` records carry `board_state_v1` / `move_v1` / `standard`.

## Next (separate PR)

Phase 3 per `HANDOFF.md`: verify the minimal trusted search (all-layers-off `MCTSAgent`) with node-internal assertions on hand-authored positions + a node-statistics inspection CLI, then the mandatory Phase 4 search-scaling gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8)_