### PR TITLE
Phase 3: minimal-search verification — rollout reward-baseline fix + node-stats CLI (gate PASS)

### DIFF
--- a/docs/agent-strength-rebuild/CURRENT_STATUS.md
+++ b/docs/agent-strength-rebuild/CURRENT_STATUS.md
@@ -2,6 +2,30 @@
 
 _Update at the start and end of every session (protocol in `MASTER_PLAN.md` §6 / master prompt §3)._
 
+## Session 2026-07-12 (session 5 — Phase 3: minimal trusted search) — PHASE 3 GATE: PASS (after fix)
+
+- **Current phase:** Phase 3 **complete** (gate PASS after the D-014 fix —
+  `phases/PHASE_3_MINIMAL_SEARCH.md`); next is the mandatory Phase 4 scaling gate.
+- **Defect found & fixed:** rollout rewards used LEAF-board score baselines, erasing the
+  immediate-gain differential between sibling moves in end-of-game rollouts (pocket position:
+  both children Q = 0.0, correct move chosen only by tie-break). Fix: `rollout_reward_baseline
+  ="root"` default (D-014); A/B pinned in tests (leaf → 0.0/0.0 blind; root → 5.0/1.0 exact).
+  Plausible plateau contributor. Era note added to `DATA_LINEAGE.md`.
+- **Work completed:** `mcts_lab/node_stats.py` CLI (root-children table, tree size, depth
+  histogram; takes `board_state_v1` JSON or seeded plies; `run_search_with_root` doubles as
+  the test harness); `tests/test_minimal_search_semantics.py` (9 tests: layer-off defaults,
+  visit conservation, pass-node sentinel, terminal reward vectors, determinism, the A/B pin).
+- **Tests passing:** search group (minimal-semantics + maxn + tactical) 17/17; layer/contract
+  suites re-run green; `mcts_lab.checks` 7/7; bounded sanity arena (champion 62.5% first-place
+  over 4 games at 100 ms — no collapse; not a strength claim).
+- **Observed for Phase 4:** the CLI makes the branching-vs-budget pathology visible — 317
+  legal moves at 16 plies: 200 iterations → pure depth-1 tree; 1 500 iterations → depth 2 with
+  visit concentration. This is exactly what the scaling study must quantify.
+- **Next recommended task:** Phase 4 — strength-vs-iteration-budget study under
+  `BENCHMARK_PROTOCOL.md` conditions (fixed pool/seeds/seat policy, iteration budgets e.g.
+  50/150/500/1500/5000), building on `training/diagnostics/search_quality.py`. Mandatory gate:
+  larger budgets must convincingly beat much smaller ones before ANY learning work.
+
 ## Session 2026-07-12 (session 4 — Phase 2 task 3: versioned formats + serialization) — PHASE 2 GATE: PASS
 
 - **Current phase:** Phase 2 **complete** (gate PASS — see `phases/PHASE_2_TRUSTED_ENGINE.md`);

--- a/docs/agent-strength-rebuild/DATA_LINEAGE.md
+++ b/docs/agent-strength-rebuild/DATA_LINEAGE.md
@@ -19,6 +19,7 @@ Rules and inventory for every dataset and model artifact. Governing rules:
 | Multi-agent framework | `MULTI_AGENT_EPOCH_RUN_ID = 20260626T055723Z` | Reporting-era cutoff for approach comparisons |
 | Rescue baseline | commit `cabe2dd7738daca661798d422ee487179640e34f` (2026-07-12) | All hashes below pinned at this commit |
 | Standard-scoring switch | Phase 2 task 1 commit (2026-07-12, protocol `rescue_v2`) | Arena results, ratings rows, and self-play `final_score` labels produced **before** this commit are house-scored; everything after defaults to standard scoring (+5 monomino-last implemented). Never mix across this boundary |
+| Rollout-baseline fix (D-014) | Phase 3 commit (2026-07-12) | All MCTS agents (champion included) evaluate endgame rollouts with root-board reward baselines from this commit on; absolute ratings and self-play data generated before/after are not strength-comparable |
 
 ## Frozen-asset inventory (sha256 @ rescue baseline)
 

--- a/docs/agent-strength-rebuild/DECISIONS.md
+++ b/docs/agent-strength-rebuild/DECISIONS.md
@@ -118,6 +118,34 @@ Format per governing master prompt §21. Statuses: Proposed / Accepted / Superse
 - **Revisit conditions:** Phase 7 dataset design (D-007) supersedes this for training data.
 - **Related:** `phases/PHASE_2_TRUSTED_ENGINE.md`, D-007.
 
+## D-014 — Rollout reward baseline: root-board deltas (fixing sibling-blind endgame values)
+
+- **Date:** 2026-07-12
+- **Status:** Accepted
+- **Context:** Phase 3 node-level verification found both children of the endgame-pocket
+  position at exactly Q = 0.0: `MCTSAgent._rollout` measured per-player rewards as score
+  deltas from the expanded leaf's own board, subtracting the points banked by the move that
+  created the leaf out of its own value. End-of-game rollouts (the only ones returning
+  deltas — cutoff-hit rollouts return static evals) could not distinguish sibling moves whose
+  difference was immediate banked points. The tactical regression test passed only via
+  move-ordering tie-break.
+- **Options considered:** root-board baseline (constant per search → child values reflect true
+  final-score differences, magnitudes unchanged in scale); absolute final scores (equivalent
+  argmax, larger magnitudes vs C=1.414 calibration); leave as-is and rely on static-eval
+  cutoff (leaves endgames blind).
+- **Evidence:** deterministic probe — legacy baseline Q 0.0/0.0 and 40/40 visits; root
+  baseline Q 5.0/1.0 (exact final-score difference) with correct visit dominance. Pinned as
+  an A/B regression test in `tests/test_minimal_search_semantics.py`. Bounded post-fix sanity
+  arena showed no collapse.
+- **Decision:** `rollout_reward_baseline="root"` is the default; "leaf" retained strictly for
+  A/B experiments; value validated in the constructor; propagated to root-parallel workers.
+- **Consequences:** rollout rewards change for every MCTS agent including the champion —
+  absolute ratings drift across this boundary (era note in `DATA_LINEAGE.md`). Reward-scale
+  mix (score-delta+bonus vs tanh×100 static eval) unchanged and flagged for Phase 4/5.
+- **Revisit conditions:** Phase 4 scaling results; Phase 5 leaf-evaluation selection may
+  replace rollout deltas entirely.
+- **Related:** `phases/PHASE_3_MINIMAL_SEARCH.md`; AUDIT_REPORT §3.1 (the sibling maxⁿ fix).
+
 ---
 
 ## Open decisions (required before their phases)

--- a/docs/agent-strength-rebuild/HANDOFF.md
+++ b/docs/agent-strength-rebuild/HANDOFF.md
@@ -15,26 +15,27 @@ _For the next agent/session. Read `MASTER_PLAN.md`, `CURRENT_STATUS.md`, `DECISI
 
 ## Exact next action
 
-**Phase 3 — minimal trusted search** (Phase 2 is COMPLETE, gate PASS:
-`phases/PHASE_2_TRUSTED_ENGINE.md`).
+**Phase 4 — the mandatory search-scaling gate** (Phases 2 AND 3 are COMPLETE, gates PASS:
+`phases/PHASE_2_TRUSTED_ENGINE.md`, `phases/PHASE_3_MINIMAL_SEARCH.md`; Phase 3 found and
+fixed the rollout-reward-baseline defect, D-014 — read it before touching search values).
 
-The candidate minimal search already exists: `MCTSAgent` with **all experimental layers off**
-(plain UCT + maxⁿ per-player vector backup, no tree reuse, deterministic-only TT, single
-thread, iteration budgets). Phase 3 is verification, not a rewrite:
-
-1. Search-correctness tests on hand-authored positions: near-terminal decisions with a known
-   best move (extend `tests/test_tactical_positions.py`), single-legal-move positions,
-   positions requiring passes (pass-node expansion), forced outcomes on reduced positions.
-   Assert node internals, not just the chosen move: root visit counts, per-player Q values
-   (mover-credited), terminal values, exploration behavior under fixed seeds.
-2. Node-statistics inspection CLI (build on `mcts/search_trace.py`): dump root children with
-   visits / per-player Q / prior ordering / depth histogram for any `Board.from_dict` position
-   (the new serialization API is the intended input format).
-3. Determinism matrix: same seed → identical tree stats across runs; iteration budgets only.
-4. Contingency if verification fails: a ~300-line reference MCTS for differential comparison.
-5. Then `phases/PHASE_3_MINIMAL_SEARCH.md` with the gate verdict, and on PASS proceed to the
-   **mandatory Phase 4 scaling gate** (`MASTER_PLAN.md` §4; builds on
-   `training/diagnostics/search_quality.py`).
+1. Strength-vs-budget study: the SAME minimal agent at increasing **iteration** budgets
+   (e.g. 50 / 150 / 500 / 1 500 / 5 000) against the fixed benchmark protocol
+   (`BENCHMARK_PROTOCOL.md`: round_robin seats, fixed seeds, iteration-deterministic budgets).
+   Start from `training/diagnostics/search_quality.py`; use `mcts_lab/node_stats.py` to record
+   root statistics (depth, visit concentration, expansion coverage) per budget.
+2. Record every run in `EXPERIMENT_LOG.md` (full reproducibility block); wall-clock costs are
+   real — budget the arena sizes before launching (a 4-game 100 ms-budget arena took ~3.5 min
+   on this container; 5 000-iteration agents are ~10× a 500-iteration agent per move).
+3. Gate: larger budgets must convincingly beat much smaller ones (e.g. 1500 > 150 > 50) with
+   defensible uncertainty. On PASS: pick the teacher budget (D-008). On FAIL: stop — diagnose
+   (backup, eval signal mix [score-delta vs tanh×100 static — flagged in D-014], branching,
+   ordering) with targeted experiments before ANY learning work (master prompt §20 escapes
+   forbidden).
+4. Known structure to quantify (from the Phase 3 CLI): at ~16 plies there are ~300+ legal
+   moves — 200 iterations yield a pure depth-1 tree; 1 500 reach depth 2. The +inf
+   unvisited-child UCB forces a full first-visit sweep at every node; whether strength still
+   scales despite this is exactly the question.
 
 Notes: browser bundle (`frontend/public/blokus_core.zip`) is generated — next
 `scripts/build_browser_core.sh` run picks up engine changes; never edit `browser_python/`

--- a/docs/agent-strength-rebuild/phases/PHASE_3_MINIMAL_SEARCH.md
+++ b/docs/agent-strength-rebuild/phases/PHASE_3_MINIMAL_SEARCH.md
@@ -1,0 +1,83 @@
+# Phase 3 — Minimal Trusted Search
+
+- **Purpose:** verify that the minimal search configuration — default `MCTSAgent`: plain UCT +
+  maxⁿ per-player vector backup, one tree, one thread, iteration budget, deterministic seeds,
+  all experimental layers off — is correct at the node level before measuring whether more
+  compute buys strength (Phase 4).
+
+- **Work completed:**
+  1. **Node-statistics inspection CLI** — `python -m mcts_lab.node_stats`: runs a seeded
+     single-tree search on a `board_state_v1` JSON position (or seeded random plies) and
+     prints the root-children table (visits, share, acting-player Q), tree size, and depth
+     histogram. Its `run_search_with_root` helper is also the test harness for node-internal
+     assertions.
+  2. **Search-semantics suite** — `tests/test_minimal_search_semantics.py`: minimal-config
+     defaults pinned (all layers off); root visit conservation; pass-node sentinel expansion;
+     terminal-rollout reward vectors (winner's own entry carries the bonus); single-legal-move
+     short-circuit; same-seed tree-statistics determinism.
+  3. **Defect found and fixed — rollout reward baseline.** Verification on the endgame-pocket
+     position (two moves: I5 fills a 5-cell pocket → final RED score 6; monomino wastes it →
+     final 2) showed BOTH root children at exactly Q = 0.0 with a 40/40 visit split: the
+     pre-existing tactical test passed only by move-ordering tie-break. Cause: `_rollout`
+     measured per-player rewards as score deltas **from the expanded leaf's own board**, so
+     the points banked by the move that created the leaf were subtracted out of its own value —
+     sibling comparisons erased exactly the component that differed. End-of-game rollouts
+     (the only ones that return deltas; cutoff-hit rollouts return static evals) were blind to
+     immediate gains precisely where precision matters most. Fix: `rollout_reward_baseline`
+     parameter, default **"root"** — deltas measured from the search-root board, shared by all
+     sibling leaves, so child values reflect true final-score differences ("leaf" retained for
+     A/B only). Propagated to root-parallel workers via config extraction. Decision D-014.
+
+- **Components changed:** `mcts/mcts_agent.py` (baseline param + capture at `select_action`),
+  `mcts/parallel.py` (worker baseline + config propagation), `mcts_lab/node_stats.py` (new).
+
+- **Tests added:** `tests/test_minimal_search_semantics.py` (9, including the A/B pin:
+  legacy "leaf" baseline → Q 0.0/0.0 blind; "root" → Q 5.0/1.0 exact separation).
+
+- **Experiments run:** distinguishing probe on the pocket position (Q values above —
+  deterministic, the smallest experiment separating "backup bug" from "value-signal bug");
+  bounded post-fix sanity arena (champion/baseline/heuristic/random, 4 games, seed 20260620,
+  100 ms budgets: champion 62.5% first-place, no collapse — sanity only, not a strength claim).
+
+- **Results / gate criteria → evidence:**
+  | Criterion | Evidence |
+  |---|---|
+  | Search deterministic under fixed seeds | same-seed root-signature equality test; iteration budgets |
+  | Multiplayer backup semantics verified | `test_maxn_backprop.py` (mover-credited vectors) + root-children Q perspective assertions |
+  | Terminal positions produce correct decisions | pocket position: correct move now wins on **value** (Q 5.0 > 1.0) and visits, not tie-break; terminal reward vector tests |
+  | Search benchmarkable independently of learning | `mcts_lab.node_stats` CLI + `run_search_with_root` harness |
+
+- **Unexpected findings:**
+  1. The reward-baseline defect above — a plausible contributor to the training plateau
+     (candidate evaluators were trained against arena outcomes played by agents whose endgame
+     search was value-blind between sibling moves).
+  2. The CLI makes the **branching-vs-budget pathology** directly visible: at a 16-ply midgame
+     position with 317 legal moves, 200 iterations produce a pure depth-1 tree (every
+     iteration expands a fresh root child, 1 visit each); 1 500 iterations reach depth 2 with
+     visits concentrating. Phase 4's scaling study must quantify exactly this.
+
+- **Gate result:** **PASS** — after the fix; the pre-fix configuration fails the
+  terminal-decision criterion (documented above rather than hidden).
+
+- **Remaining risks:** the fix changes rollout rewards for every MCTS agent (champion
+  included): absolute ratings drift across this boundary; era note added to `DATA_LINEAGE.md`.
+  The "leaf" option must not silently reappear in configs (constructor validates values).
+  Reward scale remains O(score points)+bonus vs static-eval's tanh×100 — two currencies in one
+  tree (cutoff vs terminal paths); flagged as a Phase 4/5 measurement item, not changed here.
+
+- **Decision:** D-014 in `../DECISIONS.md`.
+- **Next phase:** Phase 4 — the mandatory search-scaling gate (strength vs iteration budget,
+  fixed opponents/seeds per `BENCHMARK_PROTOCOL.md`), now measurable with trustworthy
+  node-level semantics.
+
+- **Reproduction commands:**
+  ```bash
+  python -m pytest tests/test_minimal_search_semantics.py tests/test_maxn_backprop.py \
+    tests/test_tactical_positions.py -q
+  python -m mcts_lab.node_stats --random-plies 16 --board-seed 20260620 --iterations 200
+  python -m mcts_lab.node_stats --random-plies 16 --board-seed 20260620 --iterations 1500
+  python -m mcts_lab.eval --agents champion,baseline --games 4 --seeds 20260620 --thinking-ms 100
+  ```
+
+- **Artifacts:** this PR; `mcts_lab/node_stats.py`; the A/B regression pin in
+  `tests/test_minimal_search_semantics.py`.

--- a/mcts/mcts_agent.py
+++ b/mcts/mcts_agent.py
@@ -484,6 +484,7 @@ class MCTSAgent:
         greedy_sample_size: int = 12,
         two_ply_top_k: Optional[int] = None,
         rollout_cutoff_depth: Optional[int] = None,
+        rollout_reward_baseline: str = "root",
         state_eval_weights: Optional[Dict[str, float]] = None,
         state_eval_phase_weights: Optional[Dict[str, Dict[str, float]]] = None,
         minimax_backup_alpha: float = 0.0,
@@ -605,6 +606,21 @@ class MCTSAgent:
         self.potential_mode = potential_mode
         self.learned_model_path = learned_model_path
         self.max_rollout_moves = int(max_rollout_moves)
+        # Rollout reward baseline (agent-strength rescue Phase 3 fix): "root"
+        # measures each player's score delta from the SEARCH ROOT board, so
+        # sibling leaves share one baseline and a move's own banked points
+        # count toward its value. The pre-fix "leaf" baseline (delta from the
+        # expanded leaf's board) subtracted the immediate gain of the move
+        # that created the leaf out of its own evaluation — end-of-game
+        # rollouts could not distinguish siblings whose difference was the
+        # points banked on the way in (tests/test_minimal_search_semantics).
+        # "leaf" is kept for A/B comparison only.
+        if rollout_reward_baseline not in ("root", "leaf"):
+            raise ValueError(
+                f"rollout_reward_baseline must be 'root' or 'leaf', "
+                f"got {rollout_reward_baseline!r}"
+            )
+        self.rollout_reward_baseline = rollout_reward_baseline
 
         # Layer 3 params
         self.progressive_widening_enabled = bool(progressive_widening_enabled)
@@ -789,6 +805,10 @@ class MCTSAgent:
         self._search_counter = 0
         # Track root player for minimax backups
         self._root_player: Optional[Player] = None
+        # Per-search per-player score baseline at the root board (used when
+        # rollout_reward_baseline == "root"); set wherever a search root is
+        # created (select_action, root-parallel workers, node_stats helper).
+        self._root_score_baseline: Optional[Dict[Player, int]] = None
 
         # Progressive history table: {(player, action_key): [total_reward, count]}
         # Keyed per acting player so each player's move statistics reflect
@@ -872,6 +892,7 @@ class MCTSAgent:
         # Run MCTS
         start_time = time.time()
         self._root_player = player  # Layer 4: track for minimax backups
+        self._root_score_baseline = {p: board.get_score(p) for p in _PLAYERS}
 
         # Layer 9: Compute adaptive per-move parameters
         if self.adaptive_exploration_enabled:
@@ -1838,8 +1859,15 @@ class MCTSAgent:
         sim_board = board.copy()
         current_player = player
 
-        # Initial scores for every player (rewards are score deltas per player)
-        initial_scores = {p: sim_board.get_score(p) for p in _PLAYERS}
+        # Baseline for the per-player reward deltas. "root": the search-root
+        # board's scores (shared by all sibling leaves, so a move's own banked
+        # points count toward its value). "leaf" (legacy/A-B only): this
+        # leaf's scores — erases the immediate-gain differential between
+        # siblings in end-of-game rollouts.
+        if self.rollout_reward_baseline == "root" and self._root_score_baseline is not None:
+            initial_scores = self._root_score_baseline
+        else:
+            initial_scores = {p: sim_board.get_score(p) for p in _PLAYERS}
         initial_potential = None
         if self.potential_shaping_enabled and self.learned_evaluator is not None:
             try:

--- a/mcts/parallel.py
+++ b/mcts/parallel.py
@@ -67,6 +67,7 @@ def _extract_agent_config(agent) -> dict:
         "rollout_policy": agent.rollout_policy,
         "two_ply_top_k": agent.two_ply_top_k,
         "rollout_cutoff_depth": agent.rollout_cutoff_depth,
+        "rollout_reward_baseline": agent.rollout_reward_baseline,
         "state_eval_weights": None,  # weights are internal to evaluator
         "state_eval_phase_weights": None,
         "minimax_backup_alpha": agent.minimax_backup_alpha,
@@ -195,6 +196,7 @@ def _worker_fn_with_tree(args: Tuple) -> dict:
 
     agent = MCTSAgent(**config)
     agent._root_player = player
+    agent._root_score_baseline = {p: board.get_score(p) for p in Player}
 
     move_gen = get_shared_generator()
     legal_moves = move_gen.get_legal_moves(board, player)

--- a/mcts_lab/node_stats.py
+++ b/mcts_lab/node_stats.py
@@ -1,0 +1,170 @@
+"""Node-statistics inspection CLI for the minimal trusted search
+(agent-strength rescue, Phase 3).
+
+Runs a single-tree, single-thread MCTS search on a given position and prints
+the root children table (visits, visit share, per-player Q from the acting
+player's perspective) plus whole-tree statistics (node count, depth
+histogram). Positions come from a Board.to_dict() JSON file (board_state_v1)
+or from seeded random self-play plies.
+
+Examples:
+    python -m mcts_lab.node_stats --random-plies 16 --board-seed 20260620 \
+        --iterations 400 --seed 7
+    python -m mcts_lab.node_stats --board-json position.json --iterations 1000
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from collections import Counter
+from typing import Optional, Tuple
+
+from engine.board import Board, Player
+from engine.move_generator import LegalMoveGenerator, get_shared_generator
+from mcts.mcts_agent import MCTSAgent, MCTSNode
+
+
+def run_search_with_root(agent: MCTSAgent, board: Board, player: Player) -> MCTSNode:
+    """Run the agent's iteration-budget search and RETURN the root node.
+
+    Mirrors the single-tree path of MCTSAgent.select_action (which discards
+    the root); used by this CLI and by the Phase 3 search-semantics tests to
+    assert node internals. Only valid for the minimal configuration
+    (num_workers == 1, iteration budget).
+    """
+    if agent.num_workers != 1:
+        raise ValueError("run_search_with_root requires num_workers == 1")
+    if not agent.iterations:
+        raise ValueError("run_search_with_root requires an iteration budget")
+    agent._search_counter += 1
+    agent._root_player = player
+    agent._root_score_baseline = {p: board.get_score(p) for p in Player}
+    agent._effective_exploration_constant = agent.exploration_constant
+    agent._effective_rollout_cutoff_depth = agent.rollout_cutoff_depth
+    root = MCTSNode(board, player)
+    if agent.heuristic_move_ordering or agent.progressive_widening_enabled or agent._policy_prior_active:
+        agent._sort_untried_moves(root)
+    agent._run_mcts_with_iterations(root)
+    return root
+
+
+def tree_statistics(root: MCTSNode) -> Tuple[int, Counter]:
+    """Walk the tree; return (node_count, depth histogram Counter)."""
+    depth_histogram: Counter = Counter()
+    stack = [(root, 0)]
+    count = 0
+    while stack:
+        node, depth = stack.pop()
+        count += 1
+        depth_histogram[depth] += 1
+        for child in node.children:
+            stack.append((child, depth + 1))
+    return count, depth_histogram
+
+
+def _load_board(args: argparse.Namespace) -> Board:
+    if args.board_json:
+        with open(args.board_json, "r", encoding="utf-8") as handle:
+            return Board.from_dict(json.load(handle))
+    # Seeded random self-play plies through the production move path.
+    rng = random.Random(args.board_seed)
+    board = Board()
+    generator = get_shared_generator()
+    plies = 0
+    attempts = 0
+    while plies < args.random_plies and attempts < args.random_plies * 8:
+        attempts += 1
+        player = board.current_player
+        moves = generator.get_legal_moves(board, player)
+        if not moves:
+            board._update_current_player()
+            continue
+        move = rng.choice(moves)
+        orientations = generator.piece_orientations_cache[move.piece_id]
+        board.place_piece(move.get_positions(orientations), player, move.piece_id)
+        plies += 1
+    return board
+
+
+def _resolve_player(board: Board, arg: Optional[str]) -> Player:
+    if arg is None:
+        return board.current_player
+    return Player[arg.upper()]
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m mcts_lab.node_stats", description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--board-json", help="Board.to_dict() JSON file (board_state_v1)")
+    source.add_argument("--random-plies", type=int, default=16,
+                        help="build position by playing N seeded random plies (default 16)")
+    parser.add_argument("--board-seed", type=int, default=20260620,
+                        help="seed for --random-plies position generation")
+    parser.add_argument("--player", choices=[p.name for p in Player],
+                        help="player to move (default: board's current player)")
+    parser.add_argument("--iterations", type=int, default=400)
+    parser.add_argument("--seed", type=int, default=7, help="search seed")
+    parser.add_argument("--rollout-policy", default="greedy_sample",
+                        choices=["greedy_sample", "random", "heuristic", "two_ply"])
+    parser.add_argument("--rollout-cutoff-depth", type=int, default=12)
+    parser.add_argument("--top", type=int, default=12, help="root children to print")
+    args = parser.parse_args(argv)
+
+    board = _load_board(args)
+    player = _resolve_player(board, args.player)
+    generator: LegalMoveGenerator = get_shared_generator()
+    legal_moves = generator.get_legal_moves(board, player)
+
+    print(f"Position: move_count={board.move_count}, to_move={player.name}, "
+          f"legal_moves={len(legal_moves)}")
+    print("Scores: " + ", ".join(f"{p.name}={board.get_score(p)}" for p in Player))
+    print("Pieces remaining: " + ", ".join(
+        f"{p.name}={21 - len(board.player_pieces_used[p])}" for p in Player))
+    if not legal_moves:
+        print(f"{player.name} has no legal moves (pass).")
+        return 0
+
+    agent = MCTSAgent(
+        iterations=args.iterations,
+        seed=args.seed,
+        rollout_policy=args.rollout_policy,
+        rollout_cutoff_depth=args.rollout_cutoff_depth,
+        use_transposition_table=False,
+    )
+    root = run_search_with_root(agent, board, player)
+
+    node_count, depth_histogram = tree_statistics(root)
+    print(f"\nSearch: iterations={args.iterations}, seed={args.seed}, "
+          f"rollout_policy={args.rollout_policy}, C={agent.exploration_constant}")
+    print(f"Tree: nodes={node_count}, max_depth={max(depth_histogram)}, "
+          f"root_visits={root.visits}, expanded_root_children={len(root.children)}")
+    print("Depth histogram: " + ", ".join(
+        f"d{d}={depth_histogram[d]}" for d in sorted(depth_histogram)))
+
+    children = sorted(root.children, key=lambda c: -c.visits)
+    total_visits = sum(c.visits for c in root.children) or 1
+    print(f"\nTop {min(args.top, len(children))} of {len(children)} root children "
+          f"(Q is {player.name}'s own mean reward):")
+    print(f"{'move':<28}{'visits':>8}{'share':>8}{'Q':>12}")
+    for child in children[:args.top]:
+        move = child.move
+        label = (f"piece {move.piece_id:>2} ori {move.orientation:>2} "
+                 f"@({move.anchor_row},{move.anchor_col})") if move else "PASS"
+        q = child.total_reward / child.visits if child.visits else float("nan")
+        print(f"{label:<28}{child.visits:>8}{child.visits / total_visits:>7.1%}{q:>12.2f}")
+
+    best = root.get_best_move()
+    if best is not None:
+        print(f"\nBest move: piece {best.piece_id} ori {best.orientation} "
+              f"@({best.anchor_row},{best.anchor_col})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_minimal_search_semantics.py
+++ b/tests/test_minimal_search_semantics.py
@@ -1,0 +1,184 @@
+"""
+Phase 3 (agent-strength rescue): node-internal verification of the minimal
+trusted search — the default-config MCTSAgent (plain UCT + maxⁿ per-player
+vector backup, single tree/thread, iteration budget, no experimental layers).
+
+Complements tests/test_maxn_backprop.py (unit-level backprop semantics) and
+tests/test_tactical_positions.py (final move choice) by asserting ROOT/TREE
+statistics on hand-authored and seeded positions.
+"""
+
+import numpy as np
+import pytest
+
+from engine.board import Board, Player, Position
+from engine.move_generator import get_shared_generator
+from mcts.mcts_agent import MCTSAgent, MCTSNode
+from mcts_lab.node_stats import run_search_with_root, tree_statistics
+from tests.test_tactical_positions import I5, MONO, _endgame_pocket_board
+
+
+def _agent(**overrides):
+    params = dict(iterations=60, seed=9, rollout_policy="greedy_sample",
+                  use_transposition_table=False)
+    params.update(overrides)
+    return MCTSAgent(**params)
+
+
+class TestMinimalConfigIsDefault:
+    def test_experimental_layers_default_off(self):
+        agent = MCTSAgent(iterations=10, seed=1)
+        assert not agent.rave_enabled
+        assert not agent.nst_enabled
+        assert not agent.progressive_widening_enabled
+        assert not agent.opponent_modeling_enabled
+        assert not agent.adaptive_exploration_enabled
+        assert not agent.adaptive_rollout_depth_enabled
+        assert agent.minimax_backup_alpha == 0.0
+        assert not agent.policy_prior_enabled
+        assert agent.num_workers == 1
+
+
+class TestRootStatisticsOnKnownPosition:
+    """Endgame pocket: RED has exactly two moves (I5 fills a 5-cell pocket,
+    monomino wastes it). The I5 is objectively best."""
+
+    def test_root_visit_accounting_and_best_move(self):
+        board = _endgame_pocket_board()
+        agent = _agent(iterations=80)
+        root = run_search_with_root(agent, board, Player.RED)
+
+        # Visit conservation: every iteration backs up through the root, and
+        # every root visit beyond the first-expansion sweep lands on a child.
+        assert root.visits == 80
+        assert len(root.children) == 2  # both legal moves expanded
+        assert sum(c.visits for c in root.children) == root.visits
+
+        # The pentomino must dominate visits AND carry the higher RED Q.
+        by_piece = {c.move.piece_id: c for c in root.children}
+        i5, mono = by_piece[I5], by_piece[MONO]
+        assert i5.visits > mono.visits
+        assert i5.total_reward / i5.visits > mono.total_reward / mono.visits
+        best = root.get_best_move()
+        assert best.piece_id == I5
+
+    def test_root_baseline_separates_siblings_leaf_baseline_cannot(self):
+        """The Phase 3 defect + fix, pinned as an A/B.
+
+        Both root children lead directly to terminal boards. RED's final score
+        is 6 via the I5 (pocket filled) vs 2 via the monomino (pocket wasted).
+        With the legacy "leaf" baseline the reward delta is measured from each
+        child's own board, so both children evaluate to exactly 0.0 and the
+        search is blind to the difference. With the "root" baseline (default)
+        the deltas are 5.0 vs 1.0 — the true final-score difference.
+        """
+        board = _endgame_pocket_board()
+
+        legacy = _agent(iterations=40, rollout_reward_baseline="leaf")
+        root = run_search_with_root(legacy, board, Player.RED)
+        legacy_q = {c.move.piece_id: c.total_reward / c.visits for c in root.children}
+        assert legacy_q[I5] == pytest.approx(0.0)
+        assert legacy_q[MONO] == pytest.approx(0.0)
+
+        fixed = _agent(iterations=40)  # default: rollout_reward_baseline="root"
+        root = run_search_with_root(fixed, board, Player.RED)
+        fixed_q = {c.move.piece_id: c.total_reward / c.visits for c in root.children}
+        assert fixed_q[I5] == pytest.approx(5.0)
+        assert fixed_q[MONO] == pytest.approx(1.0)
+
+    def test_children_q_is_red_perspective(self):
+        # Both root children were reached by RED's move, so each child's
+        # accumulated reward is RED's own (mover-credited maxⁿ semantics).
+        # Filling the pocket with the I5 ends RED at a strictly higher final
+        # score than wasting the monomino, so RED's mean reward must order
+        # the moves accordingly (already asserted above); here we pin the
+        # bookkeeping: children of the root store rewards for root.player.
+        board = _endgame_pocket_board()
+        agent = _agent(iterations=40)
+        root = run_search_with_root(agent, board, Player.RED)
+        for child in root.children:
+            assert child.parent is root
+            assert root.player is Player.RED  # mover whose reward the child stores
+            assert child.visits > 0
+
+
+class TestSingleLegalMove:
+    def test_select_action_short_circuits(self):
+        board = _endgame_pocket_board()
+        # Remove the monomino from RED's rack: only the I5 remains playable.
+        board.player_pieces_used[Player.RED].add(MONO)
+        gen = get_shared_generator()
+        moves = gen.get_legal_moves(board, Player.RED)
+        assert len({m.piece_id for m in moves}) == 1
+        agent = _agent()
+        chosen = agent.select_action(board, Player.RED, moves[:1])
+        assert chosen is moves[0]
+
+
+class TestPassNodeSemantics:
+    def test_blocked_player_node_expands_to_pass_child(self):
+        board = _endgame_pocket_board()
+        # BLUE to move: BLUE is fully blocked but RED still has moves, so the
+        # node must carry the pass sentinel and expand to a same-board child
+        # for the next player.
+        board.current_player = Player.BLUE
+        node = MCTSNode(board, Player.BLUE)
+        assert node.untried_moves == [None]
+        child = node.expand()
+        assert child is not None
+        assert child.move is None
+        assert child.player is not Player.BLUE
+        assert np.array_equal(child.board.grid, board.grid)
+
+    def test_terminal_position_rollout_rewards_winner(self):
+        # Fill the pocket with the I5 -> nobody can move; rollout from the
+        # terminal board must return per-player rewards with RED (the score
+        # leader by construction... BLUE owns most of the board, so BLUE wins)
+        # — assert the vector is complete and the winner's own entry carries
+        # the outright-win bonus.
+        board = _endgame_pocket_board()
+        gen = get_shared_generator()
+        i5_moves = [m for m in gen.get_legal_moves(board, Player.RED) if m.piece_id == I5]
+        orientations = gen.piece_orientations_cache[I5]
+        board.place_piece(i5_moves[0].get_positions(orientations), Player.RED, I5)
+        for p in Player:
+            assert not gen.get_legal_moves(board, p)
+
+        agent = _agent(iterations=2)
+        agent._root_player = Player.RED
+        rewards, _ = agent._rollout(board, board.current_player)
+        assert set(rewards) == set(Player)
+        scores = {p: board.get_score(p) for p in Player}
+        winner = max(scores, key=scores.get)
+        assert rewards[winner] == max(rewards.values())
+        assert rewards[winner] >= 100.0  # outright-win bonus on winner's own entry
+
+
+class TestDeterminism:
+    def _root_signature(self, seed):
+        board, _ = _seeded_midgame(20260620)
+        agent = _agent(iterations=120, seed=seed)
+        root = run_search_with_root(agent, board, board.current_player)
+        return {
+            (c.move.piece_id, c.move.orientation, c.move.anchor_row, c.move.anchor_col):
+                (c.visits, round(c.total_reward, 9))
+            for c in root.children if c.move is not None
+        }
+
+    def test_same_seed_identical_tree_stats(self):
+        assert self._root_signature(7) == self._root_signature(7)
+
+    def test_tree_statistics_walker(self):
+        board, _ = _seeded_midgame(20260621)
+        agent = _agent(iterations=50)
+        root = run_search_with_root(agent, board, board.current_player)
+        node_count, depth_histogram = tree_statistics(root)
+        assert depth_histogram[0] == 1
+        assert node_count == sum(depth_histogram.values())
+        # Every iteration expands at most one node.
+        assert node_count <= 50 + 1
+
+
+def _seeded_midgame(seed):
+    from tests.utils_game_states import generate_random_valid_state
+    return generate_random_valid_state(num_moves=14, seed=seed)


### PR DESCRIPTION
Phase 3 of the agent-strength rescue (`docs/agent-strength-rebuild/`): node-level verification of the minimal trusted search. The verification did its job — it exposed a real value-semantics defect, which is fixed here with a pinned A/B regression. Gate report: `docs/agent-strength-rebuild/phases/PHASE_3_MINIMAL_SEARCH.md` — **PASS after the fix**.

## The defect (decision D-014)

`MCTSAgent._rollout` measured per-player rewards as score deltas **from the expanded leaf's own board**. The points banked by the move that created the leaf were therefore subtracted out of that move's own value — sibling comparisons erased exactly the component that differed. Only end-of-game rollouts return deltas (cutoff-hit rollouts return static evals), so the search was value-blind between sibling moves **precisely in endgames**, where precision matters most.

Deterministic probe on the endgame-pocket regression position (I5 fills a 5-cell pocket → final score 6; monomino wastes it → final 2): both root children evaluated to **exactly Q = 0.0** with a 40/40 visit split. The existing tactical test passed only via move-ordering tie-break. This is a plausible contributor to the training plateau — arena outcomes that trained the evaluators were played by agents with sibling-blind endgame search.

## The fix

`rollout_reward_baseline` parameter, default **`"root"`**: deltas are measured from the search-root board, shared by all sibling leaves, so child values reflect true final-score differences. `"leaf"` is retained strictly for A/B experiments (constructor-validated); the baseline is propagated to root-parallel workers via the config extractor. With the fix the probe reads Q 5.0 vs 1.0 — the exact final-score difference — with correct visit dominance.

## Also in this PR

- **`mcts_lab/node_stats.py`** — node-statistics inspection CLI (Phase 3 deliverable): root-children visits/share/Q table, tree size, depth histogram; positions from `board_state_v1` JSON or seeded plies. Its `run_search_with_root` helper is the node-internal test harness. Bonus: it makes the branching-vs-budget pathology directly visible for Phase 4 (317 legal moves at 16 plies → 200 iterations is a pure depth-1 tree; 1,500 reaches depth 2).
- **`tests/test_minimal_search_semantics.py`** (9 tests): all-experimental-layers-off defaults pinned, root visit conservation, pass-node sentinel expansion, terminal reward vectors (winner's own entry carries the bonus), same-seed determinism, and the leaf-vs-root A/B pin.

## Verification

- Search group (minimal-semantics + maxⁿ + tactical): 17/17.
- All MCTS layer/contract suites (parallelization, move-policy, layers 3/5/9, agent contract, timeout): **122/122**.
- `mcts_lab.checks`: 7/7.
- Bounded sanity arena (champion/baseline/heuristic/random, 4 games, 100 ms budgets): champion 62.5% first-place — no collapse (sanity check, not a strength claim).
- Era note added to `DATA_LINEAGE.md`: ratings and self-play data before/after this commit are not strength-comparable.

## Next (separate PR)

**Phase 4 — the mandatory search-scaling gate**: strength vs iteration budget under the fixed benchmark protocol. Per the master plan, no learning work proceeds until larger budgets convincingly beat smaller ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7ZHnihmTJsz96D3h2ANd8)_